### PR TITLE
fix: Adds session expiration handling

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,6 +6,22 @@
 
 ---
 
+### Version 0.9.1
+
+**Date:** TBD
+
+- The admin application can now be deployed under a custom context path
+  (e.g. `/iam-admin/`) in addition to the root path, without requiring a
+  separate build.
+- New API endpoint for listing the rights holders of a given function within
+  an organisation. See the API documentation for details.
+- When a user's session expires while using the application, API calls now
+  detect the expired session and redirect to the login page with a clear
+  "session expired" message, instead of silently failing or showing an
+  unexpected error.
+
+---
+
 ### Version 0.9.0
 
 **Date:** 2026-04-09

--- a/iam-admin-app/backend/src/main/java/se/swedenconnect/iam/admin/config/SecurityConfiguration.java
+++ b/iam-admin-app/backend/src/main/java/se/swedenconnect/iam/admin/config/SecurityConfiguration.java
@@ -24,15 +24,18 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.client.endpoint.RestClientAuthorizationCodeTokenResponseClient;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
@@ -95,6 +98,7 @@ public class SecurityConfiguration {
     };
 
     final AuthenticationFailureHandler failureHandler = this::handleAuthenticationFailure;
+    final AuthenticationEntryPoint authenticationEntryPoint = this::handleUnauthenticated;
 
     http
         .csrf(AbstractHttpConfigurer::disable)
@@ -126,6 +130,9 @@ public class SecurityConfiguration {
         .logout(logout -> logout
             .logoutUrl("/logout")
             .logoutSuccessUrl(this.getPrefixedPath("/"))
+        )
+        .exceptionHandling(ex -> ex
+            .authenticationEntryPoint(authenticationEntryPoint)
         );
 
     return http.build();
@@ -146,6 +153,20 @@ public class SecurityConfiguration {
       log.debug("Standard login failed — redirecting to login page");
     }
     response.sendRedirect(this.getPrefixedPath("/?loginError"));
+  }
+
+  void handleUnauthenticated(
+      final @NonNull HttpServletRequest request,
+      final @NonNull HttpServletResponse response,
+      final @NonNull AuthenticationException authException) throws java.io.IOException {
+
+    if (request.getServletPath().startsWith("/api/")) {
+      response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      response.getWriter().write("{\"error\":\"session-expired\"}");
+    } else {
+      response.sendRedirect(this.getPrefixedPath("/oauth2/authorization/iam-admin"));
+    }
   }
 
   @Bean

--- a/iam-admin-app/backend/src/test/java/se/swedenconnect/iam/admin/config/SecurityConfigurationTest.java
+++ b/iam-admin-app/backend/src/test/java/se/swedenconnect/iam/admin/config/SecurityConfigurationTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.swedenconnect.iam.admin.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the unauthenticated-request handling in {@link SecurityConfiguration}.
+ *
+ * <p>The entry point distinguishes between API requests (which the SPA calls via {@code fetch})
+ * and browser navigation. API requests must receive {@code 401 JSON} so the SPA can detect a
+ * session expiry and redirect the user to the login page. Browser navigation should be redirected
+ * to the OAuth2 authorization endpoint as usual.</p>
+ *
+ * @author David Goldring
+ */
+class SecurityConfigurationTest {
+
+  private SecurityConfiguration config;
+
+  @BeforeEach
+  void setUp() {
+    this.config = new SecurityConfiguration();
+    ReflectionTestUtils.setField(this.config, "contextPath", "/");
+  }
+
+  @Test
+  void apiRequest_returnsUnauthorizedWithJsonBody() throws IOException {
+    final MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/me");
+    request.setServletPath("/api/me");
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+
+    this.config.handleUnauthenticated(request, response,
+        new InsufficientAuthenticationException("no session"));
+
+    assertThat(response.getStatus()).isEqualTo(401);
+    assertThat(response.getContentType()).startsWith(MediaType.APPLICATION_JSON_VALUE);
+    assertThat(response.getContentAsString()).isEqualTo("{\"error\":\"session-expired\"}");
+  }
+
+  @Test
+  void apiRequest_doesNotRedirect() throws IOException {
+    final MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/organizations");
+    request.setServletPath("/api/organizations");
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+
+    this.config.handleUnauthenticated(request, response,
+        new InsufficientAuthenticationException("no session"));
+
+    assertThat(response.getHeader(HttpHeaders.LOCATION)).isNull();
+  }
+
+  @Test
+  void nonApiRequest_redirectsToOAuth2Login() throws IOException {
+    final MockHttpServletRequest request = new MockHttpServletRequest("GET", "/");
+    request.setServletPath("/");
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+
+    this.config.handleUnauthenticated(request, response,
+        new InsufficientAuthenticationException("no session"));
+
+    assertThat(response.getStatus()).isEqualTo(302);
+    assertThat(response.getHeader(HttpHeaders.LOCATION))
+        .isEqualTo("/oauth2/authorization/iam-admin");
+  }
+
+  @Test
+  void nonApiRequest_withContextPath_redirectIncludesContextPath() throws IOException {
+    ReflectionTestUtils.setField(this.config, "contextPath", "/iam-admin");
+    final MockHttpServletRequest request = new MockHttpServletRequest("GET", "/iam-admin/");
+    request.setServletPath("/");
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+
+    this.config.handleUnauthenticated(request, response,
+        new InsufficientAuthenticationException("no session"));
+
+    assertThat(response.getHeader(HttpHeaders.LOCATION))
+        .isEqualTo("/iam-admin/oauth2/authorization/iam-admin");
+  }
+
+  @Test
+  void apiRequest_withContextPath_stillReturnsUnauthorized() throws IOException {
+    ReflectionTestUtils.setField(this.config, "contextPath", "/iam-admin");
+    final MockHttpServletRequest request = new MockHttpServletRequest("GET", "/iam-admin/api/session");
+    request.setServletPath("/api/session");
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+
+    this.config.handleUnauthenticated(request, response,
+        new InsufficientAuthenticationException("no session"));
+
+    assertThat(response.getStatus()).isEqualTo(401);
+    assertThat(response.getContentAsString()).isEqualTo("{\"error\":\"session-expired\"}");
+  }
+}

--- a/iam-admin-app/frontend/src/app/App.tsx
+++ b/iam-admin-app/frontend/src/app/App.tsx
@@ -19,7 +19,7 @@ import { LanguageProvider, useLanguage } from '@/app/contexts/LanguageContext';
 import { ThemeProvider } from '@/app/contexts/ThemeContext';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/app/components/ui/dialog';
 import { ErrorDialog } from '@/app/components/ErrorDialog';
-import { apiUrl } from '@/lib/api';
+import { apiUrl, apiFetch } from '@/lib/api';
 import {
   getOrganizations,
   createOrganization,
@@ -108,7 +108,7 @@ function AppContent() {
   useEffect(() => {
     const init = async () => {
       try {
-        const response = await fetch(apiUrl('api/me'));
+        const response = await apiFetch(apiUrl('api/me'));
         if (response.ok) {
           const user: CurrentUser = await response.json();
           setCurrentUser(user);

--- a/iam-admin-app/frontend/src/app/components/LoginForm.tsx
+++ b/iam-admin-app/frontend/src/app/components/LoginForm.tsx
@@ -10,7 +10,9 @@ import { apiUrl } from '@/lib/api';
 
 export function LoginForm() {
   const { t } = useLanguage();
-  const hasLoginError = new URLSearchParams(window.location.search).has('loginError');
+  const params = new URLSearchParams(window.location.search);
+  const hasLoginError = params.has('loginError');
+  const hasSessionExpired = params.has('sessionExpired');
   const [errorDescription, setErrorDescription] = useState<string | null>(null);
 
   useEffect(() => {
@@ -45,6 +47,14 @@ export function LoginForm() {
           </CardHeader>
           <CardContent>
             <div className="space-y-4">
+              {hasSessionExpired && (
+                <Alert variant="destructive">
+                  <AlertCircle className="h-4 w-4" />
+                  <AlertDescription>
+                    {t('login.sessionExpired')}
+                  </AlertDescription>
+                </Alert>
+              )}
               {hasLoginError && (
                 <Alert variant="destructive">
                   <AlertCircle className="h-4 w-4" />

--- a/iam-admin-app/frontend/src/app/contexts/LanguageContext.tsx
+++ b/iam-admin-app/frontend/src/app/contexts/LanguageContext.tsx
@@ -24,7 +24,8 @@ const translations = {
     'login.authenticating': 'Authenticating...',
     'login.demo': 'Demo: Click to simulate OpenID Connect authentication',
     'login.accessDenied': 'You do not have administrative rights to perform user delegation. Please contact your system administrator.',
-    
+    'login.sessionExpired': 'Your session has expired. Please log in again.',
+
     // Dashboard
     'dashboard.title': 'Admin Dashboard',
     'dashboard.description': 'Manage organizations and users',
@@ -218,6 +219,7 @@ const translations = {
     'login.authenticating': 'Autentiserar...',
     'login.demo': 'Demo: Klicka för att simulera OpenID Connect-autentisering',
     'login.accessDenied': 'Du har inte administrativa rättigheter att utföra användardelegering. Kontakta din systemadministratör.',
+    'login.sessionExpired': 'Din session har gått ut. Logga in igen.',
     
     // Dashboard
     'dashboard.title': 'Administratörspanel',

--- a/iam-admin-app/frontend/src/lib/api.ts
+++ b/iam-admin-app/frontend/src/lib/api.ts
@@ -1,0 +1,33 @@
+/**
+ * Returns an absolute path for a URL relative to the application base path.
+ *
+ * The base is read from document.baseURI at runtime, which reflects the
+ * <base href="..."> tag injected by the backend. This means a single built
+ * artifact works under any server.servlet.context-path without rebuilding.
+ *
+ * Usage:
+ *   fetch(apiUrl('api/me'))           → /api/me  or  /admin/api/me
+ *   window.location.href = apiUrl('') → /         or  /admin/
+ */
+export function apiUrl(path: string): string {
+  const p = path.startsWith('/') ? path.slice(1) : path;
+  return new URL(p, document.baseURI).pathname;
+}
+
+/**
+ * Wrapper around fetch that intercepts 401 Unauthorized responses.
+ *
+ * When the server-side session has expired, the backend returns 401 for API
+ * requests instead of redirecting (which fetch would follow silently). This
+ * wrapper detects that case, redirects the browser to the login page with a
+ * ?sessionExpired flag, and returns a promise that never resolves so callers
+ * do not process a stale response.
+ */
+export async function apiFetch(input: string, init?: RequestInit): Promise<Response> {
+  const response = await fetch(input, init);
+  if (response.status === 401) {
+    window.location.href = apiUrl('') + '?sessionExpired';
+    return new Promise(() => {});
+  }
+  return response;
+}

--- a/iam-admin-app/frontend/src/services/functionService.ts
+++ b/iam-admin-app/frontend/src/services/functionService.ts
@@ -5,7 +5,7 @@
 
 import type { FunctionData, FunctionType, OrganizationFunction } from '@/types';
 import { loadFromStorage, saveToStorage, STORAGE_KEYS } from './storageService';
-import { apiUrl } from '@/lib/api';
+import { apiUrl, apiFetch } from '@/lib/api';
 
 // Mock initial data (empty for org-functions)
 const INITIAL_ORG_FUNCTIONS: OrganizationFunction[] = [];
@@ -25,7 +25,7 @@ function toFunctionType(data: FunctionData): FunctionType {
  * Get all functions
  */
 export async function getFunctions(): Promise<FunctionType[]> {
-  const response = await fetch(apiUrl('api/functions'));
+  const response = await apiFetch(apiUrl('api/functions'));
   if (!response.ok) throw new Error('FETCH_FUNCTIONS_FAILED');
   const data: FunctionData[] = await response.json();
   return data.map(toFunctionType);
@@ -35,7 +35,7 @@ export async function getFunctions(): Promise<FunctionType[]> {
  * Create a new function
  */
 export async function createFunction(func: Omit<FunctionType, 'id'>): Promise<FunctionType> {
-  const response = await fetch(apiUrl('api/functions'), {
+  const response = await apiFetch(apiUrl('api/functions'), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -57,7 +57,7 @@ export async function createFunction(func: Omit<FunctionType, 'id'>): Promise<Fu
  * Update an existing function
  */
 export async function updateFunction(id: string, func: Partial<FunctionType>): Promise<FunctionType> {
-  const response = await fetch(apiUrl(`api/functions/${id}`), {
+  const response = await apiFetch(apiUrl(`api/functions/${id}`), {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -78,7 +78,7 @@ export async function updateFunction(id: string, func: Partial<FunctionType>): P
  * Delete a function
  */
 export async function deleteFunction(id: string): Promise<void> {
-  const response = await fetch(apiUrl(`api/functions/${id}`), {
+  const response = await apiFetch(apiUrl(`api/functions/${id}`), {
     method: 'DELETE',
   });
   if (response.status === 403) throw new Error('FORBIDDEN');
@@ -120,7 +120,7 @@ export async function assignFunctionsToOrganization(
 ): Promise<OrganizationFunction[]> {
   const results: OrganizationFunction[] = [];
   for (const functionId of functionIds) {
-    const response = await fetch(
+    const response = await apiFetch(
       apiUrl(`api/organizations/${organizationId}/functions/${functionId}`),
       { method: 'POST' }
     );
@@ -136,7 +136,7 @@ export async function assignFunctionsToOrganization(
  */
 export async function removeOrganizationFunctions(organizationId: string, functionIds: string[]): Promise<void> {
   for (const functionId of functionIds) {
-    const response = await fetch(
+    const response = await apiFetch(
       apiUrl(`api/organizations/${organizationId}/functions/${functionId}`),
       { method: 'DELETE' }
     );
@@ -150,8 +150,8 @@ export async function removeOrganizationFunctions(organizationId: string, functi
  * Detach a single function from an organization
  */
 export async function detachFunctionFromOrganization(organizationId: string, functionId: string): Promise<void> {
-  const response = await fetch(
-    `/api/organizations/${organizationId}/functions/${functionId}`,
+  const response = await apiFetch(
+    apiUrl(`api/organizations/${organizationId}/functions/${functionId}`),
     { method: 'DELETE' }
   );
   if (response.status === 403) throw new Error('FORBIDDEN');

--- a/iam-admin-app/frontend/src/services/organizationService.ts
+++ b/iam-admin-app/frontend/src/services/organizationService.ts
@@ -5,7 +5,7 @@
 
 import type { Organization } from '@/types';
 import { loadFromStorage, saveToStorage, STORAGE_KEYS } from './storageService';
-import { apiUrl } from '@/lib/api';
+import { apiUrl, apiFetch } from '@/lib/api';
 
 // Mock initial data
 const INITIAL_ORGANIZATIONS: Organization[] = [
@@ -30,7 +30,7 @@ export async function getOrganizations(): Promise<Organization[]> {
  * Create a new organization
  */
 export async function createOrganization(org: Omit<Organization, 'id'>): Promise<Organization> {
-  const response = await fetch(apiUrl('api/organizations'), {
+  const response = await apiFetch(apiUrl('api/organizations'), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -59,7 +59,7 @@ export async function updateOrganization(id: string, org: Partial<Organization>)
   if (org.nameSv != null) body.nameSv = org.nameSv;
   if (org.nameEn != null) body.nameEn = org.nameEn;
 
-  const response = await fetch(apiUrl(`api/organizations/${id}`), {
+  const response = await apiFetch(apiUrl(`api/organizations/${id}`), {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
@@ -83,7 +83,7 @@ export async function updateOrganization(id: string, org: Partial<Organization>)
  * Delete an organization
  */
 export async function deleteOrganization(id: string): Promise<void> {
-  const response = await fetch(apiUrl(`api/organizations/${id}`), { method: 'DELETE' });
+  const response = await apiFetch(apiUrl(`api/organizations/${id}`), { method: 'DELETE' });
   if (response.status === 403) throw new Error('FORBIDDEN');
   if (response.status === 409) throw new Error('HAS_ATTACHED_FUNCTIONS');
   if (response.status === 404) throw new Error('NOT_FOUND');

--- a/iam-admin-app/frontend/src/services/sessionService.ts
+++ b/iam-admin-app/frontend/src/services/sessionService.ts
@@ -1,8 +1,8 @@
 import { AdminSessionData } from '@/types';
-import { apiUrl } from '@/lib/api';
+import { apiUrl, apiFetch } from '@/lib/api';
 
 export async function fetchSessionData(): Promise<AdminSessionData | null> {
-  const response = await fetch(apiUrl('api/session'));
+  const response = await apiFetch(apiUrl('api/session'));
   if (response.status === 204) return null;
   if (!response.ok) throw new Error(`Session fetch failed: ${response.status}`);
   return response.json() as Promise<AdminSessionData>;

--- a/iam-admin-app/frontend/src/services/userService.ts
+++ b/iam-admin-app/frontend/src/services/userService.ts
@@ -5,7 +5,7 @@
 
 import type { User, UserOrganizationRole } from '@/types';
 import { loadFromStorage, saveToStorage, STORAGE_KEYS } from './storageService';
-import { apiUrl } from '@/lib/api';
+import { apiUrl, apiFetch } from '@/lib/api';
 
 // Mock initial data
 const INITIAL_USERS: User[] = [
@@ -52,7 +52,7 @@ export class DuplicatePinError extends Error {
  * Create a new user
  */
 export async function createUser(user: Omit<User, 'id'>): Promise<User> {
-  const response = await fetch(apiUrl('api/users'), {
+  const response = await apiFetch(apiUrl('api/users'), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -88,7 +88,7 @@ export async function createUser(user: Omit<User, 'id'>): Promise<User> {
  * Update an existing user
  */
 export async function updateUser(id: string, user: Partial<User>): Promise<User> {
-  const response = await fetch(apiUrl(`api/users/${id}`), {
+  const response = await apiFetch(apiUrl(`api/users/${id}`), {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -115,7 +115,7 @@ export async function updateUser(id: string, user: Partial<User>): Promise<User>
  * Delete a user
  */
 export async function deleteUser(id: string): Promise<void> {
-  const response = await fetch(apiUrl(`api/users/${id}`), { method: 'DELETE' });
+  const response = await apiFetch(apiUrl(`api/users/${id}`), { method: 'DELETE' });
   if (response.status === 403) throw new Error('FORBIDDEN');
   if (!response.ok) throw new Error(`Failed to delete user: ${response.status}`);
 }
@@ -124,7 +124,7 @@ export async function deleteUser(id: string): Promise<void> {
  * Get a single user by ID
  */
 export async function getUserById(id: string): Promise<User | null> {
-  const response = await fetch(apiUrl(`api/users/${id}`));
+  const response = await apiFetch(apiUrl(`api/users/${id}`));
   if (response.status === 404) return null;
   if (!response.ok) throw new Error(`Failed to fetch user: ${response.status}`);
   const data = await response.json();
@@ -162,7 +162,7 @@ export async function addUserToOrganization(
   userId: string,
   role: 'read' | 'write' | 'admin'
 ): Promise<UserOrganizationRole> {
-  const response = await fetch(
+  const response = await apiFetch(
     apiUrl(`api/organizations/${organizationId}/users/${userId}/rights`),
     {
       method: 'PUT',
@@ -192,7 +192,7 @@ export async function removeUserFromOrganization(
   userId: string,
   right: 'read' | 'write' | 'admin'
 ): Promise<void> {
-  const response = await fetch(
+  const response = await apiFetch(
     apiUrl(`api/organizations/${organizationId}/users/${userId}/rights?right=${right}`),
     { method: 'DELETE' }
   );
@@ -213,7 +213,7 @@ export async function addUserToFunction(
   userId: string,
   role: 'read' | 'write' | 'admin'
 ): Promise<UserOrganizationRole> {
-  const response = await fetch(
+  const response = await apiFetch(
     apiUrl(`api/organizations/${organizationId}/functions/${functionId}/users/${userId}/rights`),
     {
       method: 'PUT',
@@ -245,7 +245,7 @@ export async function removeUserFromFunction(
   userId: string,
   right: 'read' | 'write' | 'admin'
 ): Promise<void> {
-  const response = await fetch(
+  const response = await apiFetch(
     apiUrl(`api/organizations/${organizationId}/functions/${functionId}/users/${userId}/rights?right=${right}`),
     { method: 'DELETE' }
   );


### PR DESCRIPTION
**Backend**: 
Added a custom AuthenticationEntryPoint to the session-based filter chain. For unauthenticated requests to /api/** paths (i.e. SPA fetch calls), it returns 401 Unauthorized with a JSON body {"error":"session-expired"} instead of redirecting. Browser navigation to non-API paths still redirects to the OAuth2 login as before.

**Frontend**: 
Added apiFetch() — a thin wrapper around fetch() in lib/api.ts — that intercepts 401 responses and redirects the browser to /?sessionExpired. All API calls in the service layer and App.tsx now go through apiFetch(). The LoginForm detects ?sessionExpired and renders a localized alert ("Your session has expired. Please log in again.") in both English and Swedish.