### PR TITLE
  FIX: OrgRightsMapper always emits org_rights as a JSON array

### DIFF
--- a/iam-security/iam-security-base/src/main/java/se/swedenconnect/iam/security/claims/OrgRightsClaimParser.java
+++ b/iam-security/iam-security-base/src/main/java/se/swedenconnect/iam/security/claims/OrgRightsClaimParser.java
@@ -55,13 +55,15 @@ public class OrgRightsClaimParser {
    */
   public @NonNull OrgRightsClaim parse(final @Nullable Object rawClaim) {
     if (!(rawClaim instanceof final List<?> list) || list.isEmpty()) {
+      log.debug("[org-rights-parser] org_rights claim is absent or empty — returning empty claim");
       return new OrgRightsClaim(false, List.of());
     }
+    log.debug("[org-rights-parser] Parsing org_rights claim with {} item(s)", list.size());
 
     // First pass: check for superuser
     for (final Object item : list) {
       if (item instanceof final Map<?, ?> map && Boolean.TRUE.equals(map.get("superuser"))) {
-        log.debug("org_rights claim contains superuser marker");
+        log.debug("[org-rights-parser] Found superuser marker — returning superuser claim");
         return new OrgRightsClaim(true, List.of());
       }
     }
@@ -70,12 +72,13 @@ public class OrgRightsClaimParser {
     final List<OrgRightsClaim.OrgEntry> entries = new ArrayList<>();
     for (final Object item : list) {
       if (!(item instanceof final Map<?, ?> map)) {
+        log.debug("[org-rights-parser] Skipping non-map item in org_rights list");
         continue;
       }
 
       final String orgIdStr = (String) map.get("organization_identifier");
       if (orgIdStr == null) {
-        log.debug("Skipping org_rights entry without organization_identifier");
+        log.debug("[org-rights-parser] Skipping entry without organization_identifier");
         continue;
       }
 
@@ -84,7 +87,7 @@ public class OrgRightsClaimParser {
         orgId = OrganizationID.of(orgIdStr);
       }
       catch (final IllegalArgumentException e) {
-        log.debug("Skipping org_rights entry with invalid organization_identifier '{}': {}",
+        log.debug("[org-rights-parser] Skipping entry with invalid organization_identifier '{}': {}",
             orgIdStr, e.getMessage());
         continue;
       }
@@ -105,15 +108,22 @@ public class OrgRightsClaimParser {
             final String func = (String) funcMap.get("function");
             final String right = (String) funcMap.get("right");
             if (func != null && right != null) {
+              log.debug("[org-rights-parser]   org '{}' — function '{}', right '{}'", orgIdStr, func, right);
               functions.add(new OrgRightsClaim.FunctionEntry(func, right));
+            }
+            else {
+              log.debug("[org-rights-parser]   org '{}' — skipping function entry with missing func or right", orgIdStr);
             }
           }
         }
       }
 
+      log.debug("[org-rights-parser] Parsed org entry '{}' with {} function(s)", orgIdStr, functions.size());
       entries.add(new OrgRightsClaim.OrgEntry(orgId, name, List.copyOf(functions)));
     }
 
+    log.debug("[org-rights-parser] Finished parsing — {} org entr{} produced",
+        entries.size(), entries.size() == 1 ? "y" : "ies");
     return new OrgRightsClaim(false, List.copyOf(entries));
   }
 
@@ -134,7 +144,10 @@ public class OrgRightsClaimParser {
       final @Nullable String orgConstraint,
       final @Nullable String funcConstraint) throws InsufficientRightsException {
 
+    log.debug("[org-rights-parser] checkAdminConstraint: org='{}', function='{}'", orgConstraint, funcConstraint);
+
     if (claim.superuser()) {
+      log.debug("[org-rights-parser] Superuser — admin constraint satisfied");
       return;
     }
 
@@ -145,11 +158,13 @@ public class OrgRightsClaimParser {
           .filter(e -> orgConstraint.equals(e.orgIdentifier().toString()))
           .toList();
       if (orgs.isEmpty()) {
+        log.debug("[org-rights-parser] No rights entry found for organization '{}'", orgConstraint);
         throw new InsufficientRightsException("No rights for organization " + orgConstraint);
       }
     }
 
     if (orgs.isEmpty()) {
+      log.debug("[org-rights-parser] Claim has no org entries");
       throw new InsufficientRightsException("User has no organizational rights");
     }
 
@@ -162,6 +177,8 @@ public class OrgRightsClaimParser {
       }
       for (final OrgRightsClaim.FunctionEntry f : funcs) {
         if ("admin".equals(f.right())) {
+          log.debug("[org-rights-parser] Admin right found for org '{}', function '{}' — constraint satisfied",
+              org.orgIdentifier(), f.function());
           return;
         }
       }
@@ -201,8 +218,10 @@ public class OrgRightsClaimParser {
       final @NonNull OrgRightsClaim claim,
       final @NonNull String functionId) {
 
+    log.debug("[org-rights-parser] buildFunctionScopedAuthorities: function='{}'", functionId);
+
     if (claim.superuser()) {
-      log.debug("Superuser detected — issuing ROLE_SUPERUSER");
+      log.debug("[org-rights-parser] Superuser — issuing ROLE_SUPERUSER");
       return List.of(new SimpleGrantedAuthority("ROLE_SUPERUSER"));
     }
 
@@ -215,7 +234,7 @@ public class OrgRightsClaimParser {
               return OrganizationRight.parse(f.right());
             }
             catch (final IllegalArgumentException e) {
-              log.debug("Skipping unrecognized right value '{}' for org '{}', function '{}'",
+              log.debug("[org-rights-parser] Skipping unrecognized right '{}' for org '{}', function '{}'",
                   f.right(), org.orgIdentifier(), f.function());
               return null;
             }
@@ -223,10 +242,19 @@ public class OrgRightsClaimParser {
           .filter(r -> r != null)
           .max(Comparator.naturalOrder());
 
-      highestRight.ifPresent(right ->
-          authorities.add(FunctionScopedAuthority.of(org.orgIdentifier(), right)));
+      if (highestRight.isPresent()) {
+        log.debug("[org-rights-parser] org '{}' — highest effective right for function '{}': {}",
+            org.orgIdentifier(), functionId, highestRight.get());
+        authorities.add(FunctionScopedAuthority.of(org.orgIdentifier(), highestRight.get()));
+      }
+      else {
+        log.debug("[org-rights-parser] org '{}' — no matching entries for function '{}', skipping",
+            org.orgIdentifier(), functionId);
+      }
     }
 
+    log.debug("[org-rights-parser] Resolved {} function-scoped authorit{}", authorities.size(),
+        authorities.size() == 1 ? "y" : "ies");
     return List.copyOf(authorities);
   }
 
@@ -250,7 +278,10 @@ public class OrgRightsClaimParser {
       final @Nullable String orgConstraint,
       final @Nullable String funcConstraint) {
 
+    log.debug("[org-rights-parser] buildAuthorities: org='{}', function='{}'", orgConstraint, funcConstraint);
+
     if (claim.superuser()) {
+      log.debug("[org-rights-parser] Superuser — issuing ROLE_SUPERUSER");
       return List.of(new SimpleGrantedAuthority("ROLE_SUPERUSER"));
     }
 
@@ -259,6 +290,8 @@ public class OrgRightsClaimParser {
       orgs = orgs.stream()
           .filter(e -> orgConstraint.equals(e.orgIdentifier().toString()))
           .toList();
+      log.debug("[org-rights-parser] Filtered to org '{}': {} entr{} remaining",
+          orgConstraint, orgs.size(), orgs.size() == 1 ? "y" : "ies");
     }
 
     final List<GrantedAuthority> authorities = new ArrayList<>();
@@ -268,19 +301,25 @@ public class OrgRightsClaimParser {
         funcs = funcs.stream()
             .filter(f -> "*".equals(f.function()) || funcConstraint.equals(f.function()))
             .toList();
+        log.debug("[org-rights-parser] org '{}' — {} function entr{} after filtering for '{}'",
+            org.orgIdentifier(), funcs.size(), funcs.size() == 1 ? "y" : "ies", funcConstraint);
       }
       for (final OrgRightsClaim.FunctionEntry f : funcs) {
         try {
-          authorities.add(OrganizationalAuthority.of(
-              org.orgIdentifier(), f.function(), OrganizationRight.parse(f.right())));
+          final OrganizationalAuthority authority = OrganizationalAuthority.of(
+              org.orgIdentifier(), f.function(), OrganizationRight.parse(f.right()));
+          log.debug("[org-rights-parser] Adding authority: {}", authority.getAuthority());
+          authorities.add(authority);
         }
         catch (final IllegalArgumentException e) {
-          log.debug("Skipping unrecognized right value '{}' for org '{}', function '{}'",
+          log.debug("[org-rights-parser] Skipping unrecognized right '{}' for org '{}', function '{}'",
               f.right(), org.orgIdentifier(), f.function());
         }
       }
     }
 
+    log.debug("[org-rights-parser] Resolved {} authorit{}", authorities.size(),
+        authorities.size() == 1 ? "y" : "ies");
     return List.copyOf(authorities);
   }
 

--- a/keycloak/org-rights-mapper/src/main/java/se/swedenconnect/iam/keycloak/orgrights/OrgRightsMapper.java
+++ b/keycloak/org-rights-mapper/src/main/java/se/swedenconnect/iam/keycloak/orgrights/OrgRightsMapper.java
@@ -28,6 +28,7 @@ import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.protocol.oidc.mappers.AbstractOIDCProtocolMapper;
 import org.keycloak.protocol.oidc.mappers.OIDCAccessTokenMapper;
+import org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper;
 import org.keycloak.protocol.oidc.mappers.OIDCIDTokenMapper;
 import org.keycloak.protocol.oidc.mappers.UserInfoTokenMapper;
 import org.keycloak.provider.ProviderConfigProperty;
@@ -40,6 +41,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME;
+
 /**
  * A Keycloak OIDC protocol mapper that adds the {@code org_rights} claim to tokens. The claim
  * describes all rights the user holds across organizations and functions, derived entirely from
@@ -49,6 +52,10 @@ import java.util.stream.Collectors;
  */
 public class OrgRightsMapper extends AbstractOIDCProtocolMapper
     implements OIDCAccessTokenMapper, OIDCIDTokenMapper, UserInfoTokenMapper {
+
+
+  private static final List<ProviderConfigProperty> configProperties = new ArrayList<>();
+
 
   private static final Logger LOG = Logger.getLogger(OrgRightsMapper.class);
 
@@ -63,7 +70,7 @@ public class OrgRightsMapper extends AbstractOIDCProtocolMapper
   // ---- Token claim name ----
 
   /** The name of the claim added to the token. */
-  public static final String CLAIM_NAME = "org_rights";
+  public static final String DEFAULT_CLAIM_NAME = "org_rights";
 
   // ---- Realm role ----
 
@@ -128,6 +135,16 @@ public class OrgRightsMapper extends AbstractOIDCProtocolMapper
   /** Claim entry field: the superuser flag, used in the superuser shortcut entry. */
   public static final String CLAIM_FIELD_SUPERUSER = "superuser";
 
+
+  static {
+    OIDCAttributeMapperHelper.addTokenClaimNameConfig(configProperties);
+    OIDCAttributeMapperHelper.addIncludeInTokensConfig(configProperties, OrgRightsMapper.class);
+    configProperties.stream()
+        .filter(property ->  property.getName().equals(TOKEN_CLAIM_NAME))
+        .forEach(property -> property.setDefaultValue(DEFAULT_CLAIM_NAME));
+
+  }
+
   // ---- Special function value ----
 
   /**
@@ -160,7 +177,7 @@ public class OrgRightsMapper extends AbstractOIDCProtocolMapper
 
   @Override
   public @NonNull List<ProviderConfigProperty> getConfigProperties() {
-    return List.of();
+    return configProperties;
   }
 
   @Override
@@ -173,9 +190,9 @@ public class OrgRightsMapper extends AbstractOIDCProtocolMapper
 
     final UserModel user = userSession.getUser();
     final RealmModel realm = keycloakSession.getContext().getRealm();
+    final String claimName = resolveClaimName(mappingModel);
 
-    LOG.debugf("[org-rights] Building %s claim for user '%s'", CLAIM_NAME, user.getUsername());
-
+    LOG.debugf("[org-rights] Building %s claim for user '%s'", claimName, user.getUsername());
     // Step 1 — Check for superuser
     final RoleModel superuserRole = realm.getRole(REALM_ROLE_SUPERUSER);
     if (superuserRole != null && user.hasRole(superuserRole)) {
@@ -183,7 +200,7 @@ public class OrgRightsMapper extends AbstractOIDCProtocolMapper
           user.getUsername(), REALM_ROLE_SUPERUSER);
       final Map<String, Object> superuserEntry = new LinkedHashMap<>();
       superuserEntry.put(CLAIM_FIELD_SUPERUSER, true);
-      token.getOtherClaims().put(CLAIM_NAME, List.of(superuserEntry));
+      token.getOtherClaims().put(claimName, List.of(superuserEntry));
       return;
     }
     LOG.debugf("[org-rights] User '%s' is not a superuser", user.getUsername());
@@ -196,7 +213,7 @@ public class OrgRightsMapper extends AbstractOIDCProtocolMapper
 
     if (orgsGroup == null) {
       LOG.debugf("[org-rights] Top-level group '%s' not found in realm — emitting empty claim", GROUP_ORGS);
-      token.getOtherClaims().put(CLAIM_NAME, List.of());
+      token.getOtherClaims().put(claimName, List.of());
       return;
     }
     LOG.debugf("[org-rights] Found top-level group '%s' (id=%s)", GROUP_ORGS, orgsGroup.getId());
@@ -208,7 +225,7 @@ public class OrgRightsMapper extends AbstractOIDCProtocolMapper
     LOG.debugf("[org-rights] User '%s' belongs to %d group(s)", user.getUsername(), userGroups.size());
 
     if (userGroups.isEmpty()) {
-      token.getOtherClaims().put(CLAIM_NAME, List.of());
+      token.getOtherClaims().put(claimName, List.of());
       return;
     }
 
@@ -309,9 +326,14 @@ public class OrgRightsMapper extends AbstractOIDCProtocolMapper
     }
 
     LOG.debugf("[org-rights] Emitting '%s' claim with %d org entr%s for user '%s'",
-        CLAIM_NAME, entries.size(), entries.size() == 1 ? "y" : "ies", user.getUsername());
+        claimName, entries.size(), entries.size() == 1 ? "y" : "ies", user.getUsername());
 
-    token.getOtherClaims().put(CLAIM_NAME, entries);
+    token.getOtherClaims().put(claimName, entries);
+  }
+
+  private @NonNull String resolveClaimName(final @NonNull ProtocolMapperModel mappingModel) {
+    final String configured = mappingModel.getConfig().get(TOKEN_CLAIM_NAME);
+    return (configured != null && !configured.isBlank()) ? configured : DEFAULT_CLAIM_NAME;
   }
 
   /**

--- a/keycloak/org-rights-mapper/src/test/java/se/swedenconnect/iam/keycloak/orgrights/OrgRightsMapperTest.java
+++ b/keycloak/org-rights-mapper/src/test/java/se/swedenconnect/iam/keycloak/orgrights/OrgRightsMapperTest.java
@@ -18,7 +18,9 @@ package se.swedenconnect.iam.keycloak.orgrights;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientSessionContext;
+import org.keycloak.models.Constants;
 import org.keycloak.models.GroupModel;
 import org.keycloak.models.KeycloakContext;
 import org.keycloak.models.KeycloakSession;
@@ -27,7 +29,8 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
-import org.keycloak.representations.IDToken;
+import org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper;
+import org.keycloak.representations.AccessToken;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -49,7 +52,7 @@ import static se.swedenconnect.iam.keycloak.orgrights.OrgRightsMapper.CLAIM_FIEL
 import static se.swedenconnect.iam.keycloak.orgrights.OrgRightsMapper.CLAIM_FIELD_FUNCTIONS;
 import static se.swedenconnect.iam.keycloak.orgrights.OrgRightsMapper.CLAIM_FIELD_RIGHT;
 import static se.swedenconnect.iam.keycloak.orgrights.OrgRightsMapper.CLAIM_FIELD_SUPERUSER;
-import static se.swedenconnect.iam.keycloak.orgrights.OrgRightsMapper.CLAIM_NAME;
+import static se.swedenconnect.iam.keycloak.orgrights.OrgRightsMapper.DEFAULT_CLAIM_NAME;
 import static se.swedenconnect.iam.keycloak.orgrights.OrgRightsMapper.FUNCTION_WILDCARD;
 import static se.swedenconnect.iam.keycloak.orgrights.OrgRightsMapper.GROUP_ORGS;
 import static se.swedenconnect.iam.keycloak.orgrights.OrgRightsMapper.REALM_ROLE_SUPERUSER;
@@ -92,17 +95,26 @@ class OrgRightsMapperTest {
   @Mock
   private ClientSessionContext clientSessionCtx;
 
+  @Mock
+  private ClientModel client;
+
   @BeforeEach
   void setUp() {
     mapper = new OrgRightsMapper();
     when(keycloakSession.getContext()).thenReturn(keycloakContext);
     when(keycloakContext.getRealm()).thenReturn(realm);
+    when(keycloakContext.getClient()).thenReturn(client);
+    when(client.getAttribute(Constants.USE_LIGHTWEIGHT_ACCESS_TOKEN_ENABLED)).thenReturn(null);
     when(userSession.getUser()).thenReturn(user);
+    when(mappingModel.getConfig()).thenReturn(Map.of(
+        OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME, DEFAULT_CLAIM_NAME,
+        OIDCAttributeMapperHelper.INCLUDE_IN_ACCESS_TOKEN, "true"
+    ));
   }
 
   /**
    * Test 1: Superuser. User has the superuser realm role.
-   * Verify the claim is [{superuser: true}] and nothing else.
+   * Verify the claim is [{superuser: true}] — an array, not a bare object.
    */
   @Test
   void testSuperuser() {
@@ -110,12 +122,12 @@ class OrgRightsMapperTest {
     when(realm.getRole(REALM_ROLE_SUPERUSER)).thenReturn(superuserRole);
     when(user.hasRole(superuserRole)).thenReturn(true);
 
-    final IDToken token = new IDToken();
-    mapper.setClaim(token, mappingModel, userSession, keycloakSession, clientSessionCtx);
+    final AccessToken token = new AccessToken();
+    mapper.transformAccessToken(token, mappingModel, keycloakSession, userSession, clientSessionCtx);
 
     @SuppressWarnings("unchecked")
     final List<Map<String, Object>> orgRights =
-        (List<Map<String, Object>>) token.getOtherClaims().get(CLAIM_NAME);
+        (List<Map<String, Object>>) token.getOtherClaims().get(DEFAULT_CLAIM_NAME);
 
     assertNotNull(orgRights);
     assertEquals(1, orgRights.size());
@@ -148,12 +160,12 @@ class OrgRightsMapperTest {
 
     when(user.getGroupsStream()).thenReturn(Stream.of(writeGroup));
 
-    final IDToken token = new IDToken();
-    mapper.setClaim(token, mappingModel, userSession, keycloakSession, clientSessionCtx);
+    final AccessToken token = new AccessToken();
+    mapper.transformAccessToken(token, mappingModel, keycloakSession, userSession, clientSessionCtx);
 
     @SuppressWarnings("unchecked")
     final List<Map<String, Object>> orgRights =
-        (List<Map<String, Object>>) token.getOtherClaims().get(CLAIM_NAME);
+        (List<Map<String, Object>>) token.getOtherClaims().get(DEFAULT_CLAIM_NAME);
 
     assertNotNull(orgRights);
     assertEquals(1, orgRights.size());
@@ -200,12 +212,12 @@ class OrgRightsMapperTest {
 
     when(user.getGroupsStream()).thenReturn(Stream.of(readGroup));
 
-    final IDToken token = new IDToken();
-    mapper.setClaim(token, mappingModel, userSession, keycloakSession, clientSessionCtx);
+    final AccessToken token = new AccessToken();
+    mapper.transformAccessToken(token, mappingModel, keycloakSession, userSession, clientSessionCtx);
 
     @SuppressWarnings("unchecked")
     final List<Map<String, Object>> orgRights =
-        (List<Map<String, Object>>) token.getOtherClaims().get(CLAIM_NAME);
+        (List<Map<String, Object>>) token.getOtherClaims().get(DEFAULT_CLAIM_NAME);
 
     assertNotNull(orgRights);
     assertEquals(1, orgRights.size());
@@ -258,28 +270,22 @@ class OrgRightsMapperTest {
     final GroupModel adminB = mockGroup("adminB-id", RIGHT_GROUP_ADMIN, "orgB-id");
     when(adminB.getParent()).thenReturn(orgB);
 
-    // getSubGroupsStream called once per org during entry-building phase
-    when(orgsGroup.getSubGroupsStream())
-        .thenReturn(Stream.of(orgA, orgB))
-        .thenReturn(Stream.of(orgA, orgB));
-
+    when(orgsGroup.getSubGroupsStream()).thenReturn(Stream.of(orgA, orgB));
     when(user.getGroupsStream()).thenReturn(Stream.of(readA, adminB));
 
-    final IDToken token = new IDToken();
-    mapper.setClaim(token, mappingModel, userSession, keycloakSession, clientSessionCtx);
+    final AccessToken token = new AccessToken();
+    mapper.transformAccessToken(token, mappingModel, keycloakSession, userSession, clientSessionCtx);
 
     @SuppressWarnings("unchecked")
     final List<Map<String, Object>> orgRights =
-        (List<Map<String, Object>>) token.getOtherClaims().get(CLAIM_NAME);
+        (List<Map<String, Object>>) token.getOtherClaims().get(DEFAULT_CLAIM_NAME);
 
     assertNotNull(orgRights);
     assertEquals(2, orgRights.size());
 
-    // Entries are in insertion order (order groups were iterated by Mockito)
     final Map<String, Object> firstEntry  = orgRights.get(0);
     final Map<String, Object> secondEntry = orgRights.get(1);
 
-    // Find which is org A and which is org B by identifier
     final Map<String, Object> orgAEntry = firstEntry.get(ATTR_ORGANIZATION_IDENTIFIER).equals("1111111111")
         ? firstEntry : secondEntry;
     final Map<String, Object> orgBEntry = firstEntry.get(ATTR_ORGANIZATION_IDENTIFIER).equals("2222222222")
@@ -332,12 +338,12 @@ class OrgRightsMapperTest {
 
     when(user.getGroupsStream()).thenReturn(Stream.of(orgReadGroup, funcWriteGroup));
 
-    final IDToken token = new IDToken();
-    mapper.setClaim(token, mappingModel, userSession, keycloakSession, clientSessionCtx);
+    final AccessToken token = new AccessToken();
+    mapper.transformAccessToken(token, mappingModel, keycloakSession, userSession, clientSessionCtx);
 
     @SuppressWarnings("unchecked")
     final List<Map<String, Object>> orgRights =
-        (List<Map<String, Object>>) token.getOtherClaims().get(CLAIM_NAME);
+        (List<Map<String, Object>>) token.getOtherClaims().get(DEFAULT_CLAIM_NAME);
 
     assertNotNull(orgRights);
     assertEquals(1, orgRights.size()); // single org entry
@@ -350,7 +356,6 @@ class OrgRightsMapperTest {
         (List<Map<String, String>>) entry.get(CLAIM_FIELD_FUNCTIONS);
     assertEquals(2, functions.size());
 
-    // Find the wildcard and named entries by function value
     final Map<String, String> wildcardEntry = functions.stream()
         .filter(f -> FUNCTION_WILDCARD.equals(f.get(CLAIM_FIELD_FUNCTION)))
         .findFirst()
@@ -379,12 +384,12 @@ class OrgRightsMapperTest {
     when(unrelatedGroup.getParent()).thenReturn(null);
     when(user.getGroupsStream()).thenReturn(Stream.of(unrelatedGroup));
 
-    final IDToken token = new IDToken();
-    mapper.setClaim(token, mappingModel, userSession, keycloakSession, clientSessionCtx);
+    final AccessToken token = new AccessToken();
+    mapper.transformAccessToken(token, mappingModel, keycloakSession, userSession, clientSessionCtx);
 
     @SuppressWarnings("unchecked")
     final List<Map<String, Object>> orgRights =
-        (List<Map<String, Object>>) token.getOtherClaims().get(CLAIM_NAME);
+        (List<Map<String, Object>>) token.getOtherClaims().get(DEFAULT_CLAIM_NAME);
 
     assertNotNull(orgRights);
     assertTrue(orgRights.isEmpty());
@@ -415,13 +420,13 @@ class OrgRightsMapperTest {
 
     when(user.getGroupsStream()).thenReturn(Stream.of(writeGroup));
 
-    final IDToken token = new IDToken();
+    final AccessToken token = new AccessToken();
     // Must not throw
-    mapper.setClaim(token, mappingModel, userSession, keycloakSession, clientSessionCtx);
+    mapper.transformAccessToken(token, mappingModel, keycloakSession, userSession, clientSessionCtx);
 
     @SuppressWarnings("unchecked")
     final List<Map<String, Object>> orgRights =
-        (List<Map<String, Object>>) token.getOtherClaims().get(CLAIM_NAME);
+        (List<Map<String, Object>>) token.getOtherClaims().get(DEFAULT_CLAIM_NAME);
 
     assertNotNull(orgRights);
     assertEquals(1, orgRights.size());

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <packaging>pom</packaging>
   <version>0.9.1-SNAPSHOT</version>
 
-  <name>Sween Connect :: IAM :: Organizations and Users Registration :: Parent POM</name>
+  <name>Sweden Connect :: IAM :: Organizations and Users Registration :: Parent POM</name>
   <description>Parent POM for the Sweden Connect IAM for Organizations and Users Registration</description>
   <url>https://www.swedenconnect.se</url>
 


### PR DESCRIPTION
Implemented so that the configuration set by config script is reflected in GUI user interface. 

In include into accesstoken is set to true, you can see that it is in admin gui. 

Added debug statements so that execution path can be tracked in live applications if needed. 

Issue:
https://github.com/swedenconnect/organizations-iam-app/issues/35