### PR TITLE
fix: Wildcard rights fix

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,3 @@
+settings.local.json
+PROJECT_CONTEXT.md
+prompts/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-### Claude ###
-.claude/settings.local.json
-
 ### Common ###
 HELP.md
 target/
@@ -20,7 +17,12 @@ logs/
 .sts4-cache
 
 ### IntelliJ IDEA ###
-.idea
+### IntelliJ IDEA ###
+.idea/*
+!.idea/copyright/
+!.idea/inspectionProfiles/
+!.idea/runConfigurations/
+!.idea/codeStyles/
 *.iws
 *.iml
 *.ipr

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,94 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <JSCodeStyleSettings version="0">
+      <option name="SPACE_WITHIN_ARRAY_INITIALIZER_BRACKETS" value="true" />
+      <option name="SPACE_BEFORE_FUNCTION_LEFT_PARENTH" value="false" />
+      <option name="SPACES_WITHIN_OBJECT_LITERAL_BRACES" value="true" />
+      <option name="CHAINED_CALL_DOT_ON_NEW_LINE" value="false" />
+    </JSCodeStyleSettings>
+    <JavaCodeStyleSettings>
+      <option name="GENERATE_FINAL_LOCALS" value="true" />
+      <option name="GENERATE_FINAL_PARAMETERS" value="true" />
+      <option name="REPLACE_INSTANCEOF_AND_CAST" value="true" />
+      <option name="SPACE_AFTER_CLOSING_ANGLE_BRACKET_IN_TYPE_ARGUMENT" value="true" />
+      <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="1000000" />
+      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="100000" />
+      <option name="ALIGN_MULTILINE_RECORDS" value="false" />
+      <option name="ALIGN_TYPES_IN_MULTI_CATCH" value="false" />
+      <option name="JD_ALIGN_PARAM_COMMENTS" value="false" />
+      <option name="JD_ALIGN_EXCEPTION_COMMENTS" value="false" />
+      <option name="JD_P_AT_EMPTY_LINES" value="false" />
+      <option name="JD_DO_NOT_WRAP_ONE_LINE_COMMENTS" value="true" />
+      <option name="JD_INDENT_ON_CONTINUATION" value="true" />
+      <REPEAT_ANNOTATIONS>
+        <ANNO name="jakarta.annotation.Nonnull" />
+        <ANNO name="jakarta.annotation.Nullable" />
+      </REPEAT_ANNOTATIONS>
+    </JavaCodeStyleSettings>
+    <codeStyleSettings language="HTML">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="JAVA">
+      <option name="RIGHT_MARGIN" value="120" />
+      <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
+      <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
+      <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+      <option name="KEEP_BLANK_LINES_BETWEEN_PACKAGE_DECLARATION_AND_HEADER" value="1" />
+      <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
+      <option name="ELSE_ON_NEW_LINE" value="true" />
+      <option name="CATCH_ON_NEW_LINE" value="true" />
+      <option name="FINALLY_ON_NEW_LINE" value="true" />
+      <option name="INDENT_CASE_FROM_SWITCH" value="false" />
+      <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+      <option name="ALIGN_MULTILINE_RESOURCES" value="false" />
+      <option name="ALIGN_MULTILINE_FOR" value="false" />
+      <option name="SPACE_WITHIN_ARRAY_INITIALIZER_BRACES" value="true" />
+      <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
+      <option name="CALL_PARAMETERS_WRAP" value="1" />
+      <option name="METHOD_PARAMETERS_WRAP" value="1" />
+      <option name="RESOURCE_LIST_WRAP" value="5" />
+      <option name="EXTENDS_LIST_WRAP" value="1" />
+      <option name="THROWS_LIST_WRAP" value="1" />
+      <option name="EXTENDS_KEYWORD_WRAP" value="1" />
+      <option name="THROWS_KEYWORD_WRAP" value="1" />
+      <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
+      <option name="BINARY_OPERATION_WRAP" value="1" />
+      <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+      <option name="TERNARY_OPERATION_WRAP" value="5" />
+      <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+      <option name="KEEP_SIMPLE_LAMBDAS_IN_ONE_LINE" value="true" />
+      <option name="KEEP_SIMPLE_CLASSES_IN_ONE_LINE" value="true" />
+      <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+      <option name="ASSIGNMENT_WRAP" value="1" />
+      <option name="WRAP_COMMENTS" value="true" />
+      <option name="ASSERT_STATEMENT_COLON_ON_NEXT_LINE" value="true" />
+      <option name="VARIABLE_ANNOTATION_WRAP" value="2" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="JavaScript">
+      <option name="ELSE_ON_NEW_LINE" value="true" />
+      <option name="CATCH_ON_NEW_LINE" value="true" />
+      <option name="FINALLY_ON_NEW_LINE" value="true" />
+      <option name="IF_BRACE_FORCE" value="3" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="XML">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/copyright/Sweden_Connect.xml
+++ b/.idea/copyright/Sweden_Connect.xml
@@ -1,0 +1,6 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="notice" value="Copyright &amp;#36;today.year Sweden Connect&#10;&#10;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;    http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License." />
+    <option name="myName" value="Sweden Connect" />
+  </copyright>
+</component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,7 @@
+<component name="CopyrightManager">
+  <settings default="Sweden Connect">
+    <LanguageOptions name="__TEMPLATE__">
+      <option name="addBlankAfter" value="false" />
+    </LanguageOptions>
+  </settings>
+</component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,11 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="LanguageDetectionInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SpellCheckingInspection" enabled="false" level="TYPO" enabled_by_default="false">
+      <option name="processCode" value="true" />
+      <option name="processLiterals" value="true" />
+      <option name="processComments" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/README.md
+++ b/README.md
@@ -6,6 +6,30 @@
 
 A centralized administration application for assigning and delegating rights for organizations and users against various target systems. Built on Keycloak with custom protocol mappers, a Spring Boot admin application, and shared security libraries.
 
+## NOTE: Action required after pulling the 2026-08-17 change
+
+This change alters the `org_rights` claim format. The claim is written by the `org-rights-mapper`
+Keycloak plugin and read by the `iam-security` libraries, so both sides must be updated. If you
+only rebuild the applications, they will parse a claim in the old format and users will silently
+lose their rights.
+
+If you already have a working environment, reinstall the plugin JARs and restart Keycloak:
+
+```bash
+./compose/keycloak-scripts/install-keycloak-plugins.sh
+docker compose -f compose/docker-compose.yml restart keycloak
+```
+
+That is all. No realm configuration, group attributes, client scopes or protocol-mapper instances
+need to change.
+
+A Keycloak instance started with `start --optimized` rather than `start-dev` additionally needs an
+explicit `kc.sh build` before restarting.
+
+To confirm it worked, log in and decode an ID token for a user holding an organisation-level right:
+`"function": "*"` should be gone, replaced by one entry per attached function plus an
+`org_level_right` field. See the [release notes](docs/release-notes.md) for the full description.
+
 ## Documentation
 
 Full documentation is available at https://docs.swedenconnect.se/organizations-iam-app/index.html.

--- a/docs/iam-admin-app-apis.md
+++ b/docs/iam-admin-app-apis.md
@@ -135,8 +135,11 @@ Authorization: Bearer <token>
 **Authorization:** Requires one of:
 
 - The `superuser` realm role (`ROLE_SUPERUSER`); or
-- An `org_rights` claim granting `admin` on `(orgIdentifier, functionId)` — including
-  via the org-wide wildcard `(orgIdentifier, *, admin)`.
+- An `org_rights` claim granting `admin` on `(orgIdentifier, functionId)`. A right granted at
+  the organization level qualifies because the protocol mapper expands it onto every function
+  attached to the organization — but only for those functions. The `org_level_right` field
+  itself grants nothing, so an org-level admin has no access to a function that is not attached
+  to that organization.
 
 Authorization is evaluated before any Keycloak lookup; unauthorized callers cannot
 distinguish a non-existent org/function from an existing-but-forbidden one.

--- a/docs/iam-integration-guide.md
+++ b/docs/iam-integration-guide.md
@@ -78,13 +78,15 @@ point users can be granted rights on that function within that organization.
 
 **Rights** come in three levels: `read`, `write`, and `admin`. They are hierarchical:
 `admin` implies `write` and `read`; `write` implies `read`. A user may hold a right at
-organization level — implicitly covering all attached functions — or on a specific function
-within an organization.
+organization level — covering every function *currently attached* to that organization — or on
+a specific function within an organization.
 
 **The `org_rights` claim** is a JSON array present in ID tokens. It provides a structured
 description of all rights the authenticated user holds across all organizations and
 functions. OIDC relying parties use this claim to determine what the user may act on in the
-application's UI.
+application's UI. A right granted at organization level arrives already expanded into one entry
+per attached function, so relying parties never have to know which functions an organization
+has attached.
 
 **OAuth2 scopes for API access** follow the pattern `{orgId}:{function}:{right}`, for
 example `5590026042:demo:write`. When a client application needs to call a downstream API
@@ -297,24 +299,31 @@ The iam-security library supports two authority modes. The mode is determined by
 
 **Function-scoped mode** (`iam.security.function` is set)
 
-The starter filters the `org_rights` claim to entries relevant to the configured function
-(both direct function rights and org-wide `*` rights that implicitly cover the function).
-When both `*` and an exact function entry exist for the same organization, the highest
-effective right is used. The resulting authorities are `FunctionScopedAuthority` instances
-with the simplified form `{orgId}:{right}` — the function identifier is implicit.
+The starter filters the `org_rights` claim to entries naming the configured function. Rights
+granted at the organization level require no special handling here — the Keycloak protocol
+mapper has already expanded them into one entry per function attached to the organization, so
+they match only if the configured function is actually attached. When several entries match
+the same organization, the highest effective right is used. The resulting authorities are
+`FunctionScopedAuthority` instances with the simplified form `{orgId}:{right}` — the function
+identifier is implicit.
 
-Example: a user has `{ "function": "*", "right": "read" }` and
-`{ "function": "demo", "right": "write" }` for organization `5590026042`. The effective
-right is `write`. The resulting authority is `5590026042:write`.
+Example: a user was granted `read` at the organization level of `5590026042` (which has `demo`
+and `walletreg` attached) plus `write` on `demo`. The claim carries
+`{ "function": "demo", "right": "write" }` and `{ "function": "walletreg", "right": "read" }`,
+so a `demo`-scoped application derives the authority `5590026042:write`.
+
+The `org_level_right` field of the claim is ignored when building authorities: it is provenance,
+not a grant. An org-level admin on an organization where the configured function is not attached
+therefore receives no authority at all.
 
 Use this mode for applications that serve a single function.
 
 **Full mode** (`iam.security.function` is not set)
 
 All organizational rights are included as `OrganizationalAuthority` instances with the form
-`{orgId}:{functionId}:{right}`. The `*` function identifier means an org-wide right covering
-all attached functions. Use this mode for applications that deal with multiple functions,
-such as the IAM admin application.
+`{orgId}:{functionId}:{right}`. Every `functionId` names a function attached to the
+organization — there is no wildcard form. Use this mode for applications that deal with
+multiple functions, such as the IAM admin application.
 
 **Superusers** receive the single authority `ROLE_SUPERUSER` in both modes. Applications
 that support superuser login must include `hasRole('SUPERUSER')` alongside their regular

--- a/docs/iam-security.md
+++ b/docs/iam-security.md
@@ -179,16 +179,24 @@ iam:
 ```
 
 In this mode the library:
-- Filters the `org_rights` claim to entries relevant to the configured function — both
-  direct function rights and org-wide (`*`) rights that implicitly cover the function
-- Resolves the **highest** effective right per organization when multiple matching
-  entries exist (e.g. `*:read` and `walletreg:write` → effective right is `write`)
+- Filters the `org_rights` claim to entries naming the configured function. Rights granted at
+  the organization level need no special handling: the protocol mapper has already expanded
+  them into one entry per attached function, so they match only if the configured function is
+  actually attached to the organization
+- Resolves the **highest** effective right per organization when several matching entries
+  exist (`admin` > `write` > `read`)
 - Produces `FunctionScopedAuthority` instances with the simplified form `{orgId}:{right}`
   — the function identifier is implicit and not encoded in the authority string
+- Ignores `org_level_right` entirely — that field is provenance, not a grant
 
-Example: a user has `org_rights` with `{ "function": "*", "right": "read" }` and
-`{ "function": "walletreg", "right": "write" }` for organization `5590026042`. The
-effective right is `write`. The resulting authority is `5590026042:write`.
+Example: a user was granted `read` at the organization level of `5590026042` (which has `demo`
+and `walletreg` attached) and `write` on `walletreg`. The claim therefore carries
+`{ "function": "demo", "right": "read" }` and `{ "function": "walletreg", "right": "write" }`,
+and a `walletreg`-scoped application derives the authority `5590026042:write`.
+
+Note the consequence for an organization the function is *not* attached to: an org-level admin
+there receives **no** authority from this application, because the mapper never expanded the
+right onto a function this application knows about.
 
 Example authorities after login:
 - `5590026042:write`
@@ -586,18 +594,62 @@ For a regular user:
     "organization_identifier": "5590026042",
     "organization_name#sv": "Litsec AB",
     "organization_name#en": "Litsec AB",
+    "org_level_right": "read",
     "functions": [
-      { "function": "*",         "right": "read"  },
+      { "function": "demo",      "right": "read"  },
       { "function": "walletreg", "right": "write" }
     ]
   }
 ]
 ```
 
+Every `functions` entry names a function attached to the organization — there is no wildcard.
+A right granted at the organization level is expanded onto each attached function and recorded
+in the optional `org_level_right` field.
+
+**`org_level_right` is provenance only and confers no access.** Derive authorities exclusively
+from `functions`; use `org_level_right` only to decide whether the user may administer the
+organization itself. The field is absent when no org-level right was granted, and `functions`
+may be empty (an organization with no attached functions).
+
 For a superuser:
 ```json
 "org_rights": [{ "superuser": true }]
 ```
+
+---
+
+## Enumerating organizations vs. deciding access
+
+Two different questions are answered by two different parts of the model. Conflating them is a
+source of bugs, so the library keeps them apart:
+
+| Question | Answered by |
+|---|---|
+| **Which** organizations is this user associated with? | `OrgRightsClaim.organizations()` |
+| **What** may this user do for function X in organization Y? | the granted authorities |
+
+Authorities are derived per `functions` entry. An organization with **no attached functions**
+therefore produces no authority at all — correctly, since there is nothing to act on — and so it
+is invisible to any consumer that enumerates authorities, even when the user administers that
+organization at the organization level. Enumerate organizations from the claim instead:
+
+```java
+public @NonNull List<OrgRightsClaim.Organization> organizations()
+
+public record Organization(
+    @NonNull OrganizationID orgIdentifier,
+    @NonNull LocalizedString name,
+    @Nullable String orgLevelRight)
+```
+
+Use `organizations()` whenever the goal is to list or display organizations, and the authorities
+whenever the goal is an access decision. Never turn an enumeration result into an access decision:
+`orgLevelRight` is provenance, and treating it as a grant would give access to functions that are
+not attached to the organization.
+
+For a **superuser** the claim carries no organization entries, so `organizations()` returns an
+empty list. Fetch the full list from `/iam-api/v1/organizations` in that case.
 
 ---
 
@@ -607,9 +659,11 @@ For a superuser:
 
 Authority string form: `{orgIdentifier}:{functionId}:{right}`
 
-Examples: `5590026042:walletreg:write`, `5590026042:*:admin`
+Examples: `5590026042:walletreg:write`, `5590026042:demo:admin`
 
-The `*` function identifier means an org-wide right covering all functions.
+The function identifier always names a function attached to the organization. A right granted at
+the organization level yields one authority per attached function, because the `org_rights`
+claim it is derived from is already expanded.
 
 ```java
 OrganizationalAuthority.parse("5590026042:walletreg:write");

--- a/docs/keycloak-setup.md
+++ b/docs/keycloak-setup.md
@@ -231,15 +231,24 @@ directory, or configured as a Script Mapper if scripting is enabled.
 
   - Load the org group's attributes to obtain `organization_identifier`, `organization_name#sv`,
       `organization_name#en`.
-  - For each membership at path `orgs/{identifier}/_admin`, `/_write`, or `/_read`, add
-      a `{ "function": "*", "right": "<right>" }` entry to the `functions` array for this org.
   - For each membership at path `orgs/{identifier}/{function}/_admin`, `/_write`, or
-      `/_read`, add a `{ "function": "<function>", "right": "<right>" }` entry.
+      `/_read`, add a `{ "function": "<function>", "right": "<right>" }` entry to the
+      `functions` array for this org.
+  - For a membership at path `orgs/{identifier}/_admin`, `/_write`, or `/_read` — a right
+      granted at the organization level — record the right in the `org_level_right` field and
+      **expand** it: add one `{ "function": "<function>", "right": "<right>" }` entry for every
+      function currently attached to the organization. The attached functions are the org
+      group's sub-groups other than `_admin`, `_write` and `_read`.
   - Emit one record per organization containing all collected function entries.
 
-* A user may have both an org-level (`*`) entry and one or more function-level entries for
-   the same organization. Both are emitted — consumers take the highest right across all
-   matching entries when evaluating access to a specific function.
+* A user may hold both an org-level right and one or more function-level rights in the same
+   organization. Where they meet on the same function the **highest** right wins
+   (`admin` > `write` > `read`), so exactly one entry per function is emitted.
+
+* `org_level_right` is provenance only — it must not be treated as granting access. All
+   effective rights are in the `functions` array, which lists only attached functions. An
+   organization with no attached functions therefore yields an entry with `org_level_right` set
+   and `"functions": []`; that entry is still emitted so the organization remains enumerable.
 
 **Mapper configuration per client:**
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,6 +6,48 @@
 
 ---
 
+### Version 0.9.2
+
+**Date:** Not yet released
+
+- **Organisation-level rights are now expanded per function in the `org_rights` claim.**
+  Previously a right granted at the organisation level was emitted as the wildcard
+  `{"function": "*", "right": "..."}`. The wildcard was documented to mean "all functions
+  currently attached to the organisation", but the claim never carried the attachment set, so
+  consumers could not evaluate that and treated it as "all functions". The `org-rights-mapper`
+  Keycloak plugin now emits one entry per attached function instead, and records the
+  organisation-level grant in a new `org_level_right` field. The wildcard is gone.
+
+  `org_level_right` is **provenance only** — it says *how* a right was granted, never *what* the
+  user may do. Effective rights come exclusively from the `functions` array. Its one legitimate
+  use is deciding whether someone may administer the organisation itself, such as granting or
+  revoking organisation-level rights or editing the organisation record.
+
+  **Behaviour change:** organisation-level `admin` on an organisation with no attached functions
+  previously granted access to every function; it now grants none. More generally, a
+  function-scoped relying party no longer accepts an organisation-level right for a function that
+  was never attached to that organisation. Rights that were correct before remain unchanged — an
+  organisation-level right still covers every function actually attached.
+
+  The OAuth scope path is unaffected: Keycloak already enforced attachment there, since the
+  `{org}:{function}:{right}` client scopes are created on attach and deleted on detach.
+
+  No Keycloak configuration changes are required — the realm, group attributes, client scopes and
+  protocol-mapper instances are all unchanged. Deploy the new `org-rights-mapper` JAR as usual;
+  a `start --optimized` installation needs an explicit `kc.sh build`.
+
+- **New `OrgRightsClaim.organizations()` helper in `iam-security-base`.** Listing the
+  organisations a user is associated with is a different question from deciding what the user may
+  do, and it needs a different source. Granted authorities are derived per function, so an
+  organisation with no attached functions produces no authority and is invisible to a consumer
+  that enumerates authorities — even when the user administers it. `organizations()` enumerates
+  the claim entries instead, returning the organisation identifier, localised name and the
+  nullable organisation-level right. Authority construction is unchanged. For a superuser the
+  claim carries no organisation entries, so the method returns an empty list and the full list
+  must be fetched from `/iam-api/v1/organizations`.
+
+---
+
 ### Version 0.9.1
 
 **Date:** 2026-06-12

--- a/docs/rights-model.md
+++ b/docs/rights-model.md
@@ -246,46 +246,66 @@ structured description of all rights held by the authenticated user.
 "organization_identifier": "5561234567",
 "organization_name#sv": "Exempel AB",
 "organization_name#en": "Example Corp",
+"org_level_right": "admin",
 "functions": [
-{"function": "*", "right": "admin"}
+{"function": "walletreg", "right": "admin"},
+{"function": "eidas", "right": "admin"}
 ]
 }
 ]
 ```
 
-Rights are expressed per function within each organization entry. The special value
-`"function": "*"` means the right was granted at the organization level and applies to all
-functions currently attached to that organization. A named function entry means the right was
-granted on that specific function only.
+Rights are expressed per function within each organization entry, and every entry names a
+function that is **currently attached** to the organization. There is no wildcard: a right
+granted at the organization level is expanded by the protocol mapper into one entry per
+attached function, so consumers never have to resolve the attachment set themselves. In the
+example above the user was granted `admin` at the organization level of `5561234567`, and
+`walletreg` and `eidas` are the two functions attached to it.
+
+**`org_level_right` is provenance only — it confers no access.** It records *how* a right was
+granted (`admin`, `write` or `read` at the organization level) and is absent when the user
+holds no org-level right. Effective rights come exclusively from the `functions` array.
+Treating `org_level_right` as granting access to a function would grant access to functions
+that are not attached to the organization, which is precisely what the expansion prevents. Its
+one legitimate use is answering "may this person administer the organization itself" — for
+example whether they may grant or revoke org-level rights, or edit the organization record.
 
 A user may hold different right levels on different functions within the same organization.
-For example, `read` at org level (expressed as `*`) and `write` on a specific function are
-both represented within the same organization entry:
+For example, `read` at the organization level combined with `write` on a specific function
+yields, for an organization with `demo` and `walletreg` attached:
 
 ```json
 {
   "organization_identifier": "5590026042",
   "organization_name#sv": "Litsec AB",
   "organization_name#en": "Litsec AB",
+  "org_level_right": "read",
   "functions": [
-    {
-      "function": "*",
-      "right": "read"
-    },
     {
       "function": "demo",
       "right": "write"
+    },
+    {
+      "function": "walletreg",
+      "right": "read"
     }
   ]
 }
 ```
 
-When evaluating the effective right for a specific function, a consumer must take the
-**highest right** among all entries that match the function (either the exact function name
-or `*`). Rights are hierarchical: `admin` > `write` > `read`.
+Where the expansion and an explicit function-level right meet on the same function, the
+**highest right** wins — `demo` above is `write`, not `read`. Rights are hierarchical:
+`admin` > `write` > `read`. The mapper resolves this, so at most one entry per function is
+emitted; a consumer that nevertheless sees duplicates should take the highest.
 
-There is no top-level `right` or `scope` field on the organization entry. All right
-information lives inside the `functions` array.
+An organization with **no attached functions** produces an entry with `org_level_right` set
+and an empty `functions` array. The entry is deliberately kept so the organization remains
+enumerable (relying parties read `organization_name#*` off the claim to know which
+organizations to display), and the empty array correctly conveys that no function-level access
+follows. Consumers must handle an empty `functions` array without error.
+
+Apart from `org_level_right`, there is no top-level `right` or `scope` field on the
+organization entry. All effective right information lives inside the `functions` array.
 
 **Token placement:**
 

--- a/iam-admin-app/backend/src/main/java/se/swedenconnect/iam/admin/controllers/OrganizationController.java
+++ b/iam-admin-app/backend/src/main/java/se/swedenconnect/iam/admin/controllers/OrganizationController.java
@@ -362,12 +362,16 @@ public class OrganizationController {
         o.contactPhone());
   }
 
+  /**
+   * True if the caller holds {@code admin} at the <em>organization</em> level for the given
+   * organization, which is what updating the organization record itself requires. Derived from
+   * {@code org_level_right} — the one legitimate use of that provenance field.
+   */
   private static boolean hasOrgAdminRight(
       final AdminSessionData data,
       final String orgIdentifier) {
     return data.claim().orgEntries().stream()
         .filter(e -> orgIdentifier.equals(e.orgIdentifier().toString()))
-        .flatMap(e -> e.functions().stream())
-        .anyMatch(f -> "*".equals(f.function()) && "admin".equals(f.right()));
+        .anyMatch(e -> "admin".equals(e.orgLevelRight()));
   }
 }

--- a/iam-admin-app/backend/src/main/java/se/swedenconnect/iam/admin/controllers/SessionController.java
+++ b/iam-admin-app/backend/src/main/java/se/swedenconnect/iam/admin/controllers/SessionController.java
@@ -100,6 +100,7 @@ public class SessionController {
     return claim.orgEntries().stream()
         .map(e -> new OrgRightResponse(
             e.orgIdentifier().toString(),
+            e.orgLevelRight(),
             e.functions().stream()
                 .map(f -> new FunctionRightResponse(f.function(), f.right()))
                 .toList()))

--- a/iam-admin-app/backend/src/main/java/se/swedenconnect/iam/admin/controllers/UserRightsController.java
+++ b/iam-admin-app/backend/src/main/java/se/swedenconnect/iam/admin/controllers/UserRightsController.java
@@ -356,13 +356,18 @@ public class UserRightsController {
         : null;
   }
 
+  /**
+   * True if the caller holds {@code admin} at the <em>organization</em> level for the given
+   * organization — the stricter right required to grant or revoke org-level rights. This is the
+   * one legitimate use of {@code org_level_right}: it answers "may this person administer the
+   * organization itself", not "what may they do".
+   */
   private static boolean hasOrgAdminRight(
       final AdminSessionData data,
       final String orgIdentifier) {
     return data.claim().orgEntries().stream()
         .filter(e -> orgIdentifier.equals(e.orgIdentifier().toString()))
-        .flatMap(e -> e.functions().stream())
-        .anyMatch(f -> "*".equals(f.function()) && "admin".equals(f.right()));
+        .anyMatch(e -> "admin".equals(e.orgLevelRight()));
   }
 
   private static boolean hasFunctionAdminRight(
@@ -372,8 +377,7 @@ public class UserRightsController {
     return data.claim().orgEntries().stream()
         .filter(e -> orgIdentifier.equals(e.orgIdentifier().toString()))
         .flatMap(e -> e.functions().stream())
-        .anyMatch(f -> ("*".equals(f.function()) || functionId.equals(f.function()))
-            && "admin".equals(f.right()));
+        .anyMatch(f -> functionId.equals(f.function()) && "admin".equals(f.right()));
   }
 
 

--- a/iam-admin-app/backend/src/main/java/se/swedenconnect/iam/admin/controllers/dto/OrgRightResponse.java
+++ b/iam-admin-app/backend/src/main/java/se/swedenconnect/iam/admin/controllers/dto/OrgRightResponse.java
@@ -16,15 +16,23 @@
 package se.swedenconnect.iam.admin.controllers.dto;
 
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 
 /**
  * JSON representation of the per-org rights held by the current user.
  *
+ * <p>{@code orgLevelRight} mirrors the {@code org_level_right} field of the {@code org_rights}
+ * claim. It is provenance only — it says the right was granted at the organization level, and is
+ * used solely to decide whether the user may administer the organization itself. Effective rights
+ * come from {@code functions}, which lists only functions attached to the organization and may be
+ * empty.</p>
+ *
  * @author Martin Lindström
  */
 public record OrgRightResponse(
     @NonNull String orgIdentifier,
+    @Nullable String orgLevelRight,
     @NonNull List<FunctionRightResponse> functions) {
 }

--- a/iam-admin-app/backend/src/main/java/se/swedenconnect/iam/admin/keycloak/AdminDataBootstrapService.java
+++ b/iam-admin-app/backend/src/main/java/se/swedenconnect/iam/admin/keycloak/AdminDataBootstrapService.java
@@ -23,11 +23,9 @@ import org.springframework.stereotype.Component;
 import se.swedenconnect.iam.security.claims.OrgRightsClaim;
 import se.swedenconnect.iam.admin.keycloak.model.AdminSessionData;
 import se.swedenconnect.iam.admin.keycloak.model.FunctionInfo;
-import se.swedenconnect.iam.admin.keycloak.model.OrganizationInfo;
 
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -76,9 +74,12 @@ public class AdminDataBootstrapService {
       adminOrgIdentifiers = Set.of();
     }
     else {
-      // Derive org identifiers where the caller has admin rights
+      // Derive org identifiers where the caller has admin rights — either on a function within the
+      // organization, or at the organization level (which also covers an organization that has no
+      // functions attached, and therefore no function entries to match on).
       adminOrgIdentifiers = claim.orgEntries().stream()
-          .filter(e -> e.functions().stream().anyMatch(f -> "admin".equals(f.right())))
+          .filter(e -> "admin".equals(e.orgLevelRight())
+              || e.functions().stream().anyMatch(f -> "admin".equals(f.right())))
           .map(e -> e.orgIdentifier().getId())
           .collect(Collectors.toCollection(LinkedHashSet::new));
 
@@ -89,13 +90,7 @@ public class AdminDataBootstrapService {
             .collect(Collectors.toCollection(LinkedHashSet::new));
       }
 
-      // Fetch the minimal org details needed to filter the function list
-      final List<OrganizationInfo> adminOrgs = adminOrgIdentifiers.stream()
-          .map(id -> this.keycloakAdminClient.fetchOrganizationByIdentifier(id).orElse(null))
-          .filter(Objects::nonNull)
-          .toList();
-
-      functions = filterFunctionsForRegularAdmin(allFunctions, claim, adminOrgs);
+      functions = filterFunctionsForRegularAdmin(allFunctions, claim, adminOrgIdentifiers);
     }
 
     if (functionConstraint != null) {
@@ -115,29 +110,29 @@ public class AdminDataBootstrapService {
 
   /**
    * Returns the subset of {@code allFunctions} that the regular admin user has rights on.
+   *
+   * <p>The claim's function entries are authoritative: the protocol mapper has already expanded any
+   * organization-level right into one entry per function attached to that organization, so no
+   * organization details need to be loaded here.</p>
+   *
+   * @param allFunctions all functions defined in the realm
+   * @param claim the parsed {@code org_rights} claim
+   * @param allowedOrgIdentifiers the organizations to consider, i.e. those the caller administers
+   * @return the functions the caller has some right on; never {@code null}
    */
   private @NonNull List<FunctionInfo> filterFunctionsForRegularAdmin(
       final @NonNull List<FunctionInfo> allFunctions,
       final @NonNull OrgRightsClaim claim,
-      final @NonNull List<OrganizationInfo> allowedOrgs) {
-
-    final java.util.Map<String, OrganizationInfo> orgMap = allowedOrgs.stream()
-        .collect(Collectors.toMap(OrganizationInfo::orgIdentifier, o -> o));
+      final @NonNull Set<String> allowedOrgIdentifiers) {
 
     final Set<String> allowedFunctionIds = new LinkedHashSet<>();
 
     for (final OrgRightsClaim.OrgEntry orgEntry : claim.orgEntries()) {
-      final OrganizationInfo orgInfo = orgMap.get(orgEntry.orgIdentifier().toString());
-      if (orgInfo == null) {
+      if (!allowedOrgIdentifiers.contains(orgEntry.orgIdentifier().toString())) {
         continue;
       }
       for (final OrgRightsClaim.FunctionEntry funcEntry : orgEntry.functions()) {
-        if ("*".equals(funcEntry.function())) {
-          allowedFunctionIds.addAll(orgInfo.attachedFunctions());
-        }
-        else {
-          allowedFunctionIds.add(funcEntry.function());
-        }
+        allowedFunctionIds.add(funcEntry.function());
       }
     }
 

--- a/iam-admin-app/backend/src/test/java/se/swedenconnect/iam/admin/auth/OrgRightsOidcUserServiceTest.java
+++ b/iam-admin-app/backend/src/test/java/se/swedenconnect/iam/admin/auth/OrgRightsOidcUserServiceTest.java
@@ -109,6 +109,29 @@ class OrgRightsOidcUserServiceTest {
     claimParser.checkAdminConstraint(claim, null, null);
   }
 
+  @Test
+  void checkAdminConstraint_orgLevelAdminOnUnattachedFunction_throws() {
+    // Org-level admin, expanded by the mapper onto the only attached function ('demo').
+    // A walletreg-constrained login must be rejected — org_level_right grants nothing by itself.
+    final OrgRightsClaim claim = new OrgRightsClaim(false, List.of(
+        orgEntry("5590026042", "admin", new OrgRightsClaim.FunctionEntry("demo", "admin"))
+    ));
+
+    assertThatThrownBy(() -> claimParser.checkAdminConstraint(claim, "5590026042", "walletreg"))
+        .isInstanceOf(InsufficientRightsException.class)
+        .hasMessageContaining("walletreg");
+  }
+
+  @Test
+  void checkAdminConstraint_orgLevelAdminWithNoAttachedFunctions_throws() {
+    final OrgRightsClaim claim = new OrgRightsClaim(false, List.of(
+        orgEntry("5590026042", "admin")
+    ));
+
+    assertThatThrownBy(() -> claimParser.checkAdminConstraint(claim, null, null))
+        .isInstanceOf(InsufficientRightsException.class);
+  }
+
   // ---------------------------------------------------------------------------
   // buildAuthorities tests (delegated to OrgRightsClaimParser)
   // ---------------------------------------------------------------------------
@@ -157,6 +180,14 @@ class OrgRightsOidcUserServiceTest {
 
   private static OrgRightsClaim.OrgEntry orgEntry(final String orgId,
       final OrgRightsClaim.FunctionEntry... functions) {
-    return new OrgRightsClaim.OrgEntry(OrganizationID.of(orgId), new LocalizedString(), List.of(functions));
+    return new OrgRightsClaim.OrgEntry(
+        OrganizationID.of(orgId), new LocalizedString(), null, List.of(functions));
+  }
+
+  /** As {@link #orgEntry(String, OrgRightsClaim.FunctionEntry...)}, but with an org-level right set. */
+  private static OrgRightsClaim.OrgEntry orgEntry(final String orgId, final String orgLevelRight,
+      final OrgRightsClaim.FunctionEntry... functions) {
+    return new OrgRightsClaim.OrgEntry(
+        OrganizationID.of(orgId), new LocalizedString(), orgLevelRight, List.of(functions));
   }
 }

--- a/iam-admin-app/backend/src/test/java/se/swedenconnect/iam/admin/controllers/ListRightsHoldersControllerTest.java
+++ b/iam-admin-app/backend/src/test/java/se/swedenconnect/iam/admin/controllers/ListRightsHoldersControllerTest.java
@@ -34,6 +34,7 @@ import se.swedenconnect.iam.security.claims.OrgRightsClaimParser;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -109,20 +110,39 @@ class ListRightsHoldersControllerTest {
   }
 
   // -----------------------------------------------------------------------
-  // 200 — org-wide admin (wildcard)
+  // 200 — org-level admin, expanded onto the requested (attached) function
   // -----------------------------------------------------------------------
 
   @Test
-  void listRightsHolders_orgWideAdmin_returnsOk() {
-    setupNonSuperuserAuth(orgRightsClaimRaw(ORG, "*", "admin"));
+  void listRightsHolders_orgLevelAdmin_returnsOk() {
+    final Object claim = orgRightsClaimRawOrgLevel(ORG, "admin", FUNC, "other-function");
+    setupNonSuperuserAuth(claim);
     when(this.keycloakAdminClient.organizationExists(ORG)).thenReturn(true);
     when(this.keycloakAdminClient.isFunctionAttachedToOrg(ORG, FUNC)).thenReturn(true);
     when(this.keycloakAdminClient.fetchFunctionRightsHolders(ORG, FUNC)).thenReturn(List.of());
 
     final ResponseEntity<?> response = this.controller.listRightsHolders(ORG, FUNC,
-        jwtWithOrgRights(orgRightsClaimRaw(ORG, "*", "admin")));
+        jwtWithOrgRights(claim));
 
     assertThat(response.getStatusCode().value()).isEqualTo(200);
+  }
+
+  // -----------------------------------------------------------------------
+  // 403 — org-level admin, but the requested function is not attached to the org, so the mapper
+  // never expanded the right onto it. org_level_right must not grant access on its own.
+  // -----------------------------------------------------------------------
+
+  @Test
+  void listRightsHolders_orgLevelAdminButFunctionNotAttached_returns403() {
+    final Object claim = orgRightsClaimRawOrgLevel(ORG, "admin", "other-function");
+    setupNonSuperuserAuth(claim);
+
+    final ResponseEntity<?> response = this.controller.listRightsHolders(ORG, FUNC,
+        jwtWithOrgRights(claim));
+
+    assertThat(response.getStatusCode().value()).isEqualTo(403);
+    verify(this.keycloakAdminClient, never()).organizationExists(anyString());
+    verify(this.keycloakAdminClient, never()).fetchFunctionRightsHolders(anyString(), anyString());
   }
 
   // -----------------------------------------------------------------------
@@ -282,6 +302,22 @@ class ListRightsHoldersControllerTest {
         "organization_identifier", orgId,
         "organization_name#sv", "Test Org",
         "functions", List.of(Map.of("function", function, "right", right))));
+  }
+
+  /**
+   * Builds a raw {@code org_rights} claim value for a right granted at the organization level, as
+   * the Keycloak protocol mapper emits it: the {@code org_level_right} provenance field plus one
+   * function entry per function attached to the organization.
+   */
+  private static Object orgRightsClaimRawOrgLevel(
+      final String orgId, final String right, final String... attachedFunctions) {
+    return List.of(Map.of(
+        "organization_identifier", orgId,
+        "organization_name#sv", "Test Org",
+        "org_level_right", right,
+        "functions", Stream.of(attachedFunctions)
+            .map(f -> Map.of("function", f, "right", right))
+            .toList()));
   }
 
 }

--- a/iam-admin-app/backend/src/test/java/se/swedenconnect/iam/admin/controllers/UserRightsControllerAdminGateTest.java
+++ b/iam-admin-app/backend/src/test/java/se/swedenconnect/iam/admin/controllers/UserRightsControllerAdminGateTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2026 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.swedenconnect.iam.admin.controllers;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import se.swedenconnect.iam.admin.config.IamAdminProperties;
+import se.swedenconnect.iam.admin.controllers.dto.AddUserRightRequest;
+import se.swedenconnect.iam.admin.keycloak.AdminSessionBootstrapHandler;
+import se.swedenconnect.iam.admin.keycloak.KeycloakAdminClient;
+import se.swedenconnect.iam.admin.keycloak.model.AdminSessionData;
+import se.swedenconnect.iam.commons.types.LocalizedString;
+import se.swedenconnect.iam.commons.types.OrganizationID;
+import se.swedenconnect.iam.security.claims.OrgRightsClaim;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests the authorization gates of {@link UserRightsController}: granting rights at the
+ * organization level requires {@code org_level_right=admin}, which is strictly more than being an
+ * admin of a function within the organization.
+ *
+ * @author Martin Lindström
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class UserRightsControllerAdminGateTest {
+
+  private static final String ORG = "5590026042";
+  private static final String FUNC = "demo";
+  private static final String CALLER_ID = "caller-uuid";
+  private static final String TARGET_ID = "target-uuid";
+
+  @Mock
+  private KeycloakAdminClient keycloakAdminClient;
+
+  @Mock
+  private HttpServletRequest request;
+
+  @Mock
+  private HttpSession session;
+
+  private UserRightsController controller;
+
+  @BeforeEach
+  void setUp() {
+    final IamAdminProperties properties = new IamAdminProperties();
+    properties.setAllowOrgRights(true);
+    this.controller = new UserRightsController(this.keycloakAdminClient, properties);
+
+    when(this.request.getSession(false)).thenReturn(this.session);
+
+    final OidcUser caller = mock(OidcUser.class);
+    when(caller.getSubject()).thenReturn(CALLER_ID);
+    SecurityContextHolder.getContext().setAuthentication(
+        new TestingAuthenticationToken(caller, "n/a"));
+
+    when(this.keycloakAdminClient.organizationExists(ORG)).thenReturn(true);
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  /**
+   * A caller who is admin of a function within the organization — but was not granted admin at the
+   * organization level — must not be able to grant org-level rights.
+   */
+  @Test
+  void addUserToOrg_functionAdminOnly_returns403() {
+    setupSession(orgEntry(ORG, null, new OrgRightsClaim.FunctionEntry(FUNC, "admin")));
+
+    final ResponseEntity<?> response = this.controller.addUserToOrg(
+        ORG, TARGET_ID, new AddUserRightRequest("read"), this.request);
+
+    assertThat(response.getStatusCode().value()).isEqualTo(403);
+    verify(this.keycloakAdminClient, never()).addUserToOrgRight(anyString(), anyString(), anyString());
+  }
+
+  /** A caller with admin at the organization level may grant org-level rights. */
+  @Test
+  void addUserToOrg_orgLevelAdmin_returns204() {
+    setupSession(orgEntry(ORG, "admin", new OrgRightsClaim.FunctionEntry(FUNC, "admin")));
+
+    final ResponseEntity<?> response = this.controller.addUserToOrg(
+        ORG, TARGET_ID, new AddUserRightRequest("admin"), this.request);
+
+    assertThat(response.getStatusCode().value()).isEqualTo(204);
+    verify(this.keycloakAdminClient).addUserToOrgRight(ORG, TARGET_ID, "admin");
+  }
+
+  /**
+   * Org-level admin on an organization with no attached functions still permits granting org-level
+   * rights — the empty functions array does not weaken the org-level gate.
+   */
+  @Test
+  void addUserToOrg_orgLevelAdminWithNoAttachedFunctions_returns204() {
+    setupSession(orgEntry(ORG, "admin"));
+
+    final ResponseEntity<?> response = this.controller.addUserToOrg(
+        ORG, TARGET_ID, new AddUserRightRequest("admin"), this.request);
+
+    assertThat(response.getStatusCode().value()).isEqualTo(204);
+    verify(this.keycloakAdminClient).addUserToOrgRight(ORG, TARGET_ID, "admin");
+  }
+
+  /** Function-level grants still work for a function admin. */
+  @Test
+  void addUserToFunction_functionAdmin_returns204() {
+    setupSession(orgEntry(ORG, null, new OrgRightsClaim.FunctionEntry(FUNC, "admin")));
+    when(this.keycloakAdminClient.isFunctionAttachedToOrg(ORG, FUNC)).thenReturn(true);
+
+    final ResponseEntity<?> response = this.controller.addUserToFunction(
+        ORG, FUNC, TARGET_ID, new AddUserRightRequest("admin"), this.request);
+
+    assertThat(response.getStatusCode().value()).isEqualTo(204);
+    verify(this.keycloakAdminClient).addUserToFunctionRight(ORG, FUNC, TARGET_ID, "admin");
+  }
+
+  /**
+   * A caller holding org-level admin on one organization may not grant org-level rights in a
+   * different organization.
+   */
+  @Test
+  void addUserToOrg_orgLevelAdminOnDifferentOrg_returns403() {
+    setupSession(orgEntry("5561234567", "admin"));
+
+    final ResponseEntity<?> response = this.controller.addUserToOrg(
+        ORG, TARGET_ID, new AddUserRightRequest("read"), this.request);
+
+    assertThat(response.getStatusCode().value()).isEqualTo(403);
+    verify(this.keycloakAdminClient, never()).addUserToOrgRight(anyString(), anyString(), anyString());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private void setupSession(final OrgRightsClaim.OrgEntry... entries) {
+    final AdminSessionData data = new AdminSessionData(false, null, null, List.of(), Set.of(ORG),
+        new OrgRightsClaim(false, List.of(entries)));
+    when(this.session.getAttribute(AdminSessionBootstrapHandler.SESSION_DATA_ATTR)).thenReturn(data);
+  }
+
+  private static OrgRightsClaim.OrgEntry orgEntry(final String orgId, final String orgLevelRight,
+      final OrgRightsClaim.FunctionEntry... functions) {
+    return new OrgRightsClaim.OrgEntry(
+        OrganizationID.of(orgId), new LocalizedString(), orgLevelRight, List.of(functions));
+  }
+}

--- a/iam-admin-app/backend/src/test/java/se/swedenconnect/iam/admin/keycloak/AdminDataBootstrapServiceTest.java
+++ b/iam-admin-app/backend/src/test/java/se/swedenconnect/iam/admin/keycloak/AdminDataBootstrapServiceTest.java
@@ -26,14 +26,11 @@ import se.swedenconnect.iam.commons.types.LocalizedString;
 import se.swedenconnect.iam.commons.types.OrganizationID;
 import se.swedenconnect.iam.admin.keycloak.model.AdminSessionData;
 import se.swedenconnect.iam.admin.keycloak.model.FunctionInfo;
-import se.swedenconnect.iam.admin.keycloak.model.OrganizationInfo;
 import se.swedenconnect.iam.security.claims.OrgRightsClaim;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 /**
@@ -60,19 +57,21 @@ class AdminDataBootstrapServiceTest {
     return new FunctionInfo(id, new LocalizedString(), null);
   }
 
-  private static OrganizationInfo orgInfo(final String orgIdentifier, final String groupId,
-      final List<String> attachedFunctions) {
-    return new OrganizationInfo(orgIdentifier, new LocalizedString(), groupId,
-        attachedFunctions, null, null);
-  }
-
   private static OrgRightsClaim superuserClaim() {
     return new OrgRightsClaim(true, List.of());
   }
 
   private static OrgRightsClaim.OrgEntry orgEntry(final String orgId,
       final OrgRightsClaim.FunctionEntry... functions) {
-    return new OrgRightsClaim.OrgEntry(OrganizationID.of(orgId), new LocalizedString(), List.of(functions));
+    return new OrgRightsClaim.OrgEntry(
+        OrganizationID.of(orgId), new LocalizedString(), null, List.of(functions));
+  }
+
+  /** As {@link #orgEntry(String, OrgRightsClaim.FunctionEntry...)}, but with an org-level right set. */
+  private static OrgRightsClaim.OrgEntry orgEntry(final String orgId, final String orgLevelRight,
+      final OrgRightsClaim.FunctionEntry... functions) {
+    return new OrgRightsClaim.OrgEntry(
+        OrganizationID.of(orgId), new LocalizedString(), orgLevelRight, List.of(functions));
   }
 
   @BeforeEach
@@ -191,14 +190,12 @@ class AdminDataBootstrapServiceTest {
   @Test
   void bootstrap_regularUser_adminOrgIdentifiersDerivedFromClaim() {
     final FunctionInfo demo = functionInfo("demo");
-    final OrganizationInfo org = orgInfo("5590026042", "group-1", List.of("demo"));
 
+    // Org-level admin, already expanded by the mapper onto the attached function 'demo'
     final OrgRightsClaim claim = new OrgRightsClaim(false, List.of(
-        orgEntry("5590026042", new OrgRightsClaim.FunctionEntry("*", "admin"))));
+        orgEntry("5590026042", "admin", new OrgRightsClaim.FunctionEntry("demo", "admin"))));
 
     when(keycloakAdminClient.fetchAllFunctions()).thenReturn(List.of(demo));
-    when(keycloakAdminClient.fetchOrganizationByIdentifier("5590026042"))
-        .thenReturn(Optional.of(org));
 
     final AdminSessionData result =
         service.bootstrap(claim, SUBJECT, null, null);
@@ -206,5 +203,48 @@ class AdminDataBootstrapServiceTest {
     assertThat(result.adminOrgIdentifiers()).containsExactly("5590026042");
     assertThat(result.currentUserIsSuperuser()).isFalse();
     assertThat(result.functions()).containsExactly(demo);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Test 8: the function list follows the claim's function entries only — a function that is not
+  // attached to the organization is never granted, even to an org-level admin
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void bootstrap_regularUser_unattachedFunctionNotIncluded() {
+    final FunctionInfo demo = functionInfo("demo");
+    final FunctionInfo walletreg = functionInfo("walletreg");
+
+    // Org-level admin on an org where only 'demo' is attached
+    final OrgRightsClaim claim = new OrgRightsClaim(false, List.of(
+        orgEntry("5590026042", "admin", new OrgRightsClaim.FunctionEntry("demo", "admin"))));
+
+    when(keycloakAdminClient.fetchAllFunctions()).thenReturn(List.of(demo, walletreg));
+
+    final AdminSessionData result =
+        service.bootstrap(claim, SUBJECT, null, null);
+
+    assertThat(result.functions()).containsExactly(demo);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Test 9: org-level admin on an organization with no attached functions still counts as an
+  // administered organization, but yields no functions
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void bootstrap_regularUser_orgLevelAdminWithNoAttachedFunctions() {
+    final FunctionInfo demo = functionInfo("demo");
+
+    final OrgRightsClaim claim = new OrgRightsClaim(false, List.of(
+        orgEntry("5590026042", "admin")));
+
+    when(keycloakAdminClient.fetchAllFunctions()).thenReturn(List.of(demo));
+
+    final AdminSessionData result =
+        service.bootstrap(claim, SUBJECT, null, null);
+
+    assertThat(result.adminOrgIdentifiers()).containsExactly("5590026042");
+    assertThat(result.functions()).isEmpty();
   }
 }

--- a/iam-admin-app/frontend/src/app/App.tsx
+++ b/iam-admin-app/frontend/src/app/App.tsx
@@ -818,7 +818,7 @@ function AppContent() {
         isOpen={isOrgFormOpen}
         isSuperuser={sessionData?.superuser ?? false}
         currentUserOrgAdminIds={(sessionData?.orgRights ?? [])
-          .filter(o => o.functions.some(f => f.function === '*' && f.right === 'admin'))
+          .filter(o => o.orgLevelRight === 'admin')
           .map(o => o.orgIdentifier)}
         onClose={() => {
           setIsOrgFormOpen(false);

--- a/iam-admin-app/frontend/src/types.ts
+++ b/iam-admin-app/frontend/src/types.ts
@@ -52,12 +52,16 @@ export interface FunctionData {
 }
 
 export interface UserFunctionRight {
-  function: string; // "*" = org-wide
+  function: string; // a function attached to the organization
   right: 'admin' | 'write' | 'read';
 }
 
 export interface UserOrgRight {
   orgIdentifier: string;
+  // Provenance only: the right granted at the organization level, absent if none. Confers no
+  // access by itself — effective rights are in `functions`, which lists only attached functions
+  // and may be empty. Use it solely to decide who may administer the organization itself.
+  orgLevelRight?: 'admin' | 'write' | 'read' | null;
   functions: UserFunctionRight[];
 }
 

--- a/iam-admin-app/frontend/src/utils.ts
+++ b/iam-admin-app/frontend/src/utils.ts
@@ -18,7 +18,10 @@ export function formatPersonalIdentityNumber(value: string): string {
   return digits.length > 4 ? `${digits.slice(0, -4)}-${digits.slice(-4)}` : value;
 }
 
-/** True if the current user may manage users/roles at the whole-org level. */
+/**
+ * True if the current user may manage users/roles at the whole-org level. This requires admin
+ * granted at the organization level, which is stricter than admin on a single function.
+ */
 export function canAdminOrg(
   superuser: boolean,
   orgRights: UserOrgRight[],
@@ -26,7 +29,7 @@ export function canAdminOrg(
 ): boolean {
   if (superuser) return true;
   const org = orgRights.find((o) => o.orgIdentifier === orgId);
-  return org?.functions.some((f) => f.function === '*' && f.right === 'admin') ?? false;
+  return org?.orgLevelRight === 'admin';
 }
 
 /** True if the current user may manage users/roles for a specific function within an org. */
@@ -39,8 +42,6 @@ export function canAdminFunction(
   if (superuser) return true;
   const org = orgRights.find((o) => o.orgIdentifier === orgId);
   return (
-    org?.functions.some(
-      (f) => (f.function === '*' || f.function === functionId) && f.right === 'admin',
-    ) ?? false
+    org?.functions.some((f) => f.function === functionId && f.right === 'admin') ?? false
   );
 }

--- a/iam-security/iam-security-base/src/main/java/se/swedenconnect/iam/security/claims/OrgRightsClaim.java
+++ b/iam-security/iam-security-base/src/main/java/se/swedenconnect/iam/security/claims/OrgRightsClaim.java
@@ -16,6 +16,7 @@
 package se.swedenconnect.iam.security.claims;
 
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import se.swedenconnect.iam.commons.types.LocalizedString;
 import se.swedenconnect.iam.commons.types.OrganizationID;
 
@@ -27,30 +28,88 @@ import java.util.List;
  * <p>A claim is either a superuser marker or a list of organization entries, each holding
  * a set of function-level rights.</p>
  *
+ * <p>Use {@link #organizations()} to enumerate the organizations the user is associated with, and
+ * the authorities built by {@link OrgRightsClaimParser} to decide what the user may do.</p>
+ *
  * @author Martin Lindström
  */
 public record OrgRightsClaim(boolean superuser, @NonNull List<OrgEntry> orgEntries) {
 
   /**
-   * Represents a single organization with its associated function rights.
+   * Enumerates the organizations the user is associated with.
+   *
+   * <p>This answers "<em>which</em> organizations is this user associated with", which is a
+   * different question from "<em>what</em> may this user do for function X in organization Y".
+   * The latter is answered by the granted authorities, which are derived per function entry and
+   * therefore omit an organization that has no functions attached — even when the user genuinely
+   * administers it at the organization level. Use this method whenever the goal is to list or
+   * display organizations, and the authorities whenever the goal is an access decision.</p>
+   *
+   * <p>For a <strong>superuser</strong> the claim carries no organization entries, so this returns
+   * an empty list. A caller that needs the full organization list for a superuser must fetch it
+   * from the IAM Service API ({@code /iam-api/v1/organizations}) instead.</p>
+   *
+   * @return one {@link Organization} per organization entry, in claim order; never {@code null}
+   */
+  public @NonNull List<Organization> organizations() {
+    return this.orgEntries.stream()
+        .map(e -> new Organization(e.orgIdentifier(), e.name(), e.orgLevelRight()))
+        .toList();
+  }
+
+  /**
+   * An organization the user is associated with, without any function-level right information.
+   *
+   * <p>{@code orgLevelRight} carries the same meaning as in {@link OrgEntry}: it is provenance,
+   * recording that the right was granted at the organization level, and confers no access to any
+   * function. It is {@code null} when the user's rights in this organization are all
+   * function-level.</p>
    *
    * @param orgIdentifier the organization identifier
    * @param name the localized name of the organization
+   * @param orgLevelRight the right granted at the organization level ({@code admin}, {@code write}
+   *     or {@code read}), or {@code null} if the user holds no org-level right
+   */
+  public record Organization(
+      @NonNull OrganizationID orgIdentifier,
+      @NonNull LocalizedString name,
+      @Nullable String orgLevelRight) {
+  }
+
+  /**
+   * Represents a single organization with its associated function rights.
+   *
+   * <p>{@code orgLevelRight} is <em>provenance only</em>: it records that the user was granted a
+   * right at the organization level, but confers no access in itself. A right granted at the
+   * organization level has already been expanded by the protocol mapper into one
+   * {@link FunctionEntry} per function attached to the organization, so effective rights come
+   * exclusively from {@link #functions()}. Treating {@code orgLevelRight} as granting access to a
+   * function would grant access to functions that are not attached to the organization. Its one
+   * legitimate use is deciding whether the user may administer the organization itself.</p>
+   *
+   * <p>{@link #functions()} may be empty while {@code orgLevelRight} is set — that is an
+   * organization with no attached functions, which consumers must handle without error.</p>
+   *
+   * @param orgIdentifier the organization identifier
+   * @param name the localized name of the organization
+   * @param orgLevelRight the right granted at the organization level ({@code admin}, {@code write}
+   *     or {@code read}), or {@code null} if the user holds no org-level right
    * @param functions the list of function-right entries for this organization
    */
   public record OrgEntry(
       @NonNull OrganizationID orgIdentifier,
       @NonNull LocalizedString name,
+      @Nullable String orgLevelRight,
       @NonNull List<FunctionEntry> functions) {
   }
 
   /**
    * Represents a function-right pair within an organization.
    *
-   * <p>The {@code function} field is either a named function identifier (e.g. {@code walletreg})
-   * or the literal {@code *} indicating an org-wide right that applies to all functions.</p>
+   * <p>The {@code function} field is always a named function identifier (e.g. {@code walletreg})
+   * of a function attached to the organization.</p>
    *
-   * @param function the function identifier, or {@code *} for org-wide
+   * @param function the function identifier
    * @param right the right level: {@code admin}, {@code write}, or {@code read}
    */
   public record FunctionEntry(@NonNull String function, @NonNull String right) {

--- a/iam-security/iam-security-base/src/main/java/se/swedenconnect/iam/security/claims/OrgRightsClaimParser.java
+++ b/iam-security/iam-security-base/src/main/java/se/swedenconnect/iam/security/claims/OrgRightsClaimParser.java
@@ -34,11 +34,13 @@ import java.util.Optional;
  *
  * <p>The {@code org_rights} claim is a JSON array produced by the KeyCloak protocol mapper.
  * Each entry is either a superuser marker ({@code {"superuser": true}}) or an organization object with an
- * {@code organization_identifier} and a {@code functions} array.</p>
+ * {@code organization_identifier}, a {@code functions} array, and an optional
+ * {@code org_level_right}.</p>
  *
  * <p>Authorities follow the pattern {@code {org_identifier}:{function}:{right}}, e.g.
- * {@code 5590026042:walletreg:admin} or {@code 5590026042:*:admin} for org-wide rights,
- * represented as {@link OrganizationalAuthority} instances.</p>
+ * {@code 5590026042:walletreg:admin}, represented as {@link OrganizationalAuthority} instances.
+ * They are derived exclusively from the {@code functions} array; {@code org_level_right} is
+ * provenance and grants nothing on its own.</p>
  *
  * <p>Superusers receive the single authority {@code ROLE_SUPERUSER}.</p>
  *
@@ -111,7 +113,9 @@ public class OrgRightsClaimParser {
         }
       }
 
-      entries.add(new OrgRightsClaim.OrgEntry(orgId, name, List.copyOf(functions)));
+      final String orgLevelRight = map.get("org_level_right") instanceof final String r ? r : null;
+
+      entries.add(new OrgRightsClaim.OrgEntry(orgId, name, orgLevelRight, List.copyOf(functions)));
     }
 
     return new OrgRightsClaim(false, List.copyOf(entries));
@@ -157,7 +161,7 @@ public class OrgRightsClaimParser {
       List<OrgRightsClaim.FunctionEntry> funcs = org.functions();
       if (funcConstraint != null) {
         funcs = funcs.stream()
-            .filter(f -> "*".equals(f.function()) || funcConstraint.equals(f.function()))
+            .filter(f -> funcConstraint.equals(f.function()))
             .toList();
       }
       for (final OrgRightsClaim.FunctionEntry f : funcs) {
@@ -184,8 +188,10 @@ public class OrgRightsClaimParser {
    * Builds a {@link GrantedAuthority} list in function-scoped mode.
    *
    * <p>In function-scoped mode the application is configured for a single function. The
-   * {@code org_rights} claim is filtered to entries relevant to {@code functionId} — both
-   * entries with an exact function match and entries with the org-wide ({@code *}) wildcard.
+   * {@code org_rights} claim is filtered to the entries matching {@code functionId}. An
+   * organization-level right needs no special handling here: the protocol mapper has already
+   * expanded it into one entry per attached function, so it matches only if {@code functionId} is
+   * actually attached to the organization.
    * For each organization the highest effective right across all matching entries is resolved
    * ({@code admin} &gt; {@code write} &gt; {@code read}), and a single
    * {@link FunctionScopedAuthority} of the form {@code {orgId}:{right}} is produced per
@@ -209,7 +215,7 @@ public class OrgRightsClaimParser {
     final List<GrantedAuthority> authorities = new ArrayList<>();
     for (final OrgRightsClaim.OrgEntry org : claim.orgEntries()) {
       final Optional<OrganizationRight> highestRight = org.functions().stream()
-          .filter(f -> "*".equals(f.function()) || functionId.equals(f.function()))
+          .filter(f -> functionId.equals(f.function()))
           .map(f -> {
             try {
               return OrganizationRight.parse(f.right());
@@ -234,7 +240,7 @@ public class OrgRightsClaimParser {
    * Builds a {@link GrantedAuthority} list from the claim, restricted to the given constraints.
    *
    * <p>When {@code orgConstraint} is set, only entries for that organization are included.
-   * When {@code funcConstraint} is set, only entries for that function (or {@code *}) are included. Both may be
+   * When {@code funcConstraint} is set, only entries for that function are included. Both may be
    * {@code null} to include all effective rights.</p>
    *
    * <p>For regular users the authorities are {@link OrganizationalAuthority} instances. For superusers
@@ -266,7 +272,7 @@ public class OrgRightsClaimParser {
       List<OrgRightsClaim.FunctionEntry> funcs = org.functions();
       if (funcConstraint != null) {
         funcs = funcs.stream()
-            .filter(f -> "*".equals(f.function()) || funcConstraint.equals(f.function()))
+            .filter(f -> funcConstraint.equals(f.function()))
             .toList();
       }
       for (final OrgRightsClaim.FunctionEntry f : funcs) {

--- a/iam-security/iam-security-base/src/test/java/se/swedenconnect/iam/security/claims/OrgRightsClaimOrganizationsTest.java
+++ b/iam-security/iam-security-base/src/test/java/se/swedenconnect/iam/security/claims/OrgRightsClaimOrganizationsTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026 Sweden Connect
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.swedenconnect.iam.security.claims;
+
+import org.junit.jupiter.api.Test;
+import se.swedenconnect.iam.commons.types.LocalizedString;
+import se.swedenconnect.iam.commons.types.OrganizationID;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link OrgRightsClaim#organizations()}.
+ *
+ * @author Martin Lindström
+ */
+class OrgRightsClaimOrganizationsTest {
+
+  /** An organization with attached functions and an org-level right is enumerated with that right. */
+  @Test
+  void organizations_withFunctionsAndOrgLevelRight() {
+    final OrgRightsClaim claim = new OrgRightsClaim(false, List.of(
+        orgEntry("5590026042", "admin",
+            new OrgRightsClaim.FunctionEntry("demo", "admin"),
+            new OrgRightsClaim.FunctionEntry("walletreg", "admin"))
+    ));
+
+    assertThat(claim.organizations()).hasSize(1);
+
+    final OrgRightsClaim.Organization org = claim.organizations().getFirst();
+    assertThat(org.orgIdentifier()).isEqualTo(OrganizationID.of("5590026042"));
+    assertThat(org.name().get("en")).isEqualTo("Litsec AB");
+    assertThat(org.orgLevelRight()).isEqualTo("admin");
+  }
+
+  /** An organization where all rights are function-level is enumerated with a null org-level right. */
+  @Test
+  void organizations_withFunctionsAndNoOrgLevelRight() {
+    final OrgRightsClaim claim = new OrgRightsClaim(false, List.of(
+        orgEntry("5590026042", null, new OrgRightsClaim.FunctionEntry("demo", "write"))
+    ));
+
+    assertThat(claim.organizations()).hasSize(1);
+    assertThat(claim.organizations().getFirst().orgLevelRight()).isNull();
+  }
+
+  /**
+   * An organization with an org-level right but no attached functions is still enumerated. It
+   * produces no authority, so enumeration is the only way for a consumer to learn about it.
+   */
+  @Test
+  void organizations_withOrgLevelRightAndEmptyFunctions() {
+    final OrgRightsClaim claim = new OrgRightsClaim(false, List.of(
+        orgEntry("5561234567", "admin")
+    ));
+
+    assertThat(claim.organizations()).hasSize(1);
+
+    final OrgRightsClaim.Organization org = claim.organizations().getFirst();
+    assertThat(org.orgIdentifier()).isEqualTo(OrganizationID.of("5561234567"));
+    assertThat(org.orgLevelRight()).isEqualTo("admin");
+  }
+
+  /** Every organization entry is enumerated, in claim order. */
+  @Test
+  void organizations_preservesClaimOrder() {
+    final OrgRightsClaim claim = new OrgRightsClaim(false, List.of(
+        orgEntry("5590026042", null, new OrgRightsClaim.FunctionEntry("demo", "read")),
+        orgEntry("5561234567", "admin")
+    ));
+
+    assertThat(claim.organizations())
+        .extracting(o -> o.orgIdentifier().toString())
+        .containsExactly("5590026042", "5561234567");
+  }
+
+  /**
+   * A superuser claim carries no organization entries, so enumeration is empty — the full list must
+   * be fetched from the IAM Service API instead.
+   */
+  @Test
+  void organizations_superuser_isEmpty() {
+    final OrgRightsClaim claim = new OrgRightsClaim(true, List.of());
+
+    assertThat(claim.organizations()).isEmpty();
+  }
+
+  /** An empty claim enumerates no organizations. */
+  @Test
+  void organizations_emptyClaim_isEmpty() {
+    final OrgRightsClaim claim = new OrgRightsClaim(false, List.of());
+
+    assertThat(claim.organizations()).isEmpty();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private static OrgRightsClaim.OrgEntry orgEntry(final String orgId, final String orgLevelRight,
+      final OrgRightsClaim.FunctionEntry... functions) {
+    final LocalizedString name = new LocalizedString();
+    name.add("sv", "Litsec AB");
+    name.add("en", "Litsec AB");
+    return new OrgRightsClaim.OrgEntry(
+        OrganizationID.of(orgId), name, orgLevelRight, List.of(functions));
+  }
+}

--- a/iam-security/iam-security-base/src/test/java/se/swedenconnect/iam/security/claims/OrgRightsClaimParserFunctionScopedTest.java
+++ b/iam-security/iam-security-base/src/test/java/se/swedenconnect/iam/security/claims/OrgRightsClaimParserFunctionScopedTest.java
@@ -35,7 +35,14 @@ class OrgRightsClaimParserFunctionScopedTest {
   private final OrgRightsClaimParser parser = new OrgRightsClaimParser();
 
   private static OrgRightsClaim.OrgEntry orgEntry(final String orgId, final OrgRightsClaim.FunctionEntry... functions) {
-    return new OrgRightsClaim.OrgEntry(OrganizationID.of(orgId), new LocalizedString(), List.of(functions));
+    return new OrgRightsClaim.OrgEntry(OrganizationID.of(orgId), new LocalizedString(), null, List.of(functions));
+  }
+
+  /** As {@link #orgEntry(String, OrgRightsClaim.FunctionEntry...)}, but with an org-level right set. */
+  private static OrgRightsClaim.OrgEntry orgEntry(final String orgId, final String orgLevelRight,
+      final OrgRightsClaim.FunctionEntry... functions) {
+    return new OrgRightsClaim.OrgEntry(
+        OrganizationID.of(orgId), new LocalizedString(), orgLevelRight, List.of(functions));
   }
 
   /** Superuser always receives ROLE_SUPERUSER regardless of function. */
@@ -46,15 +53,42 @@ class OrgRightsClaimParserFunctionScopedTest {
     assertThat(authorities).containsExactly(new SimpleGrantedAuthority("ROLE_SUPERUSER"));
   }
 
-  /** User with only a wildcard (*) right gets that right as a FunctionScopedAuthority. */
+  /**
+   * An org-level right the mapper expanded onto the configured function produces that right as a
+   * FunctionScopedAuthority.
+   */
   @Test
-  void wildcardOnly_producesCorrectAuthority() {
+  void orgLevelRightExpandedOntoFunction_producesCorrectAuthority() {
     final OrgRightsClaim claim = new OrgRightsClaim(false, List.of(
-        orgEntry("5590026042", new OrgRightsClaim.FunctionEntry("*", "read"))
+        orgEntry("5590026042", "read", new OrgRightsClaim.FunctionEntry("walletreg", "read"))
     ));
     final List<GrantedAuthority> authorities = this.parser.buildFunctionScopedAuthorities(claim, "walletreg");
     assertThat(authorities).containsExactly(
         FunctionScopedAuthority.of(OrganizationID.of("5590026042"), OrganizationRight.READ));
+  }
+
+  /**
+   * An org-level right grants nothing for a function that is not attached to the organization — the
+   * mapper expanded it only onto {@code demo}, so a walletreg-scoped application sees no right.
+   * {@code orgLevelRight} must never be treated as a grant in its own right.
+   */
+  @Test
+  void orgLevelRightOnUnattachedFunction_producesNoAuthority() {
+    final OrgRightsClaim claim = new OrgRightsClaim(false, List.of(
+        orgEntry("5590026042", "admin", new OrgRightsClaim.FunctionEntry("demo", "admin"))
+    ));
+    final List<GrantedAuthority> authorities = this.parser.buildFunctionScopedAuthorities(claim, "walletreg");
+    assertThat(authorities).isEmpty();
+  }
+
+  /** An org-level right on an organization with no attached functions grants nothing. */
+  @Test
+  void orgLevelRightWithNoAttachedFunctions_producesNoAuthority() {
+    final OrgRightsClaim claim = new OrgRightsClaim(false, List.of(
+        orgEntry("5590026042", "admin")
+    ));
+    final List<GrantedAuthority> authorities = this.parser.buildFunctionScopedAuthorities(claim, "walletreg");
+    assertThat(authorities).isEmpty();
   }
 
   /** User with only an exact function match right gets that right as a FunctionScopedAuthority. */
@@ -68,12 +102,12 @@ class OrgRightsClaimParserFunctionScopedTest {
         FunctionScopedAuthority.of(OrganizationID.of("5590026042"), OrganizationRight.WRITE));
   }
 
-  /** When both wildcard and exact function entries are present, the highest right wins. */
+  /** When several entries name the same function, the highest right wins. */
   @Test
-  void wildcardAndExact_highestRightWins() {
+  void duplicateFunctionEntries_highestRightWins() {
     final OrgRightsClaim claim = new OrgRightsClaim(false, List.of(
         orgEntry("5590026042",
-            new OrgRightsClaim.FunctionEntry("*", "read"),
+            new OrgRightsClaim.FunctionEntry("walletreg", "read"),
             new OrgRightsClaim.FunctionEntry("walletreg", "write"))
     ));
     final List<GrantedAuthority> authorities = this.parser.buildFunctionScopedAuthorities(claim, "walletreg");
@@ -95,8 +129,8 @@ class OrgRightsClaimParserFunctionScopedTest {
   @Test
   void multipleOrgs_eachGetHighestRight() {
     final OrgRightsClaim claim = new OrgRightsClaim(false, List.of(
-        orgEntry("5590026042",
-            new OrgRightsClaim.FunctionEntry("*", "read"),
+        orgEntry("5590026042", "read",
+            new OrgRightsClaim.FunctionEntry("demo", "read"),
             new OrgRightsClaim.FunctionEntry("walletreg", "admin")),
         orgEntry("5561234567",
             new OrgRightsClaim.FunctionEntry("walletreg", "write"))

--- a/iam-security/iam-security-base/src/test/java/se/swedenconnect/iam/security/claims/OrgRightsClaimParserParseTest.java
+++ b/iam-security/iam-security-base/src/test/java/se/swedenconnect/iam/security/claims/OrgRightsClaimParserParseTest.java
@@ -59,6 +59,62 @@ class OrgRightsClaimParserParseTest {
     assertThat(entry.name().get("de")).isEqualTo("Litsec AB (Deutsch)");
   }
 
+  /** An entry without {@code org_level_right} parses to a {@code null} org-level right. */
+  @Test
+  void parse_orgLevelRightAbsent() {
+    final List<Map<String, Object>> rawClaim = List.of(Map.of(
+        "organization_identifier", "5590026042",
+        "functions", List.of(Map.of("function", "walletreg", "right", "write"))
+    ));
+
+    final OrgRightsClaim claim = this.parser.parse(rawClaim);
+
+    assertThat(claim.orgEntries()).hasSize(1);
+    assertThat(claim.orgEntries().getFirst().orgLevelRight()).isNull();
+  }
+
+  /** {@code org_level_right} is read alongside the expanded function entries. */
+  @Test
+  void parse_orgLevelRightPresent() {
+    final List<Map<String, Object>> rawClaim = List.of(Map.of(
+        "organization_identifier", "5590026042",
+        "org_level_right", "admin",
+        "functions", List.of(
+            Map.of("function", "demo", "right", "admin"),
+            Map.of("function", "walletreg", "right", "admin")
+        )
+    ));
+
+    final OrgRightsClaim claim = this.parser.parse(rawClaim);
+
+    assertThat(claim.orgEntries()).hasSize(1);
+
+    final OrgRightsClaim.OrgEntry entry = claim.orgEntries().getFirst();
+    assertThat(entry.orgLevelRight()).isEqualTo("admin");
+    assertThat(entry.functions()).containsExactly(
+        new OrgRightsClaim.FunctionEntry("demo", "admin"),
+        new OrgRightsClaim.FunctionEntry("walletreg", "admin"));
+  }
+
+  /**
+   * An org-level right on an organization with no attached functions parses to an entry with an
+   * empty functions list — the entry is kept so the organization remains enumerable.
+   */
+  @Test
+  void parse_orgLevelRightWithEmptyFunctions() {
+    final List<Map<String, Object>> rawClaim = List.of(Map.of(
+        "organization_identifier", "5590026042",
+        "org_level_right", "admin",
+        "functions", List.of()
+    ));
+
+    final OrgRightsClaim claim = this.parser.parse(rawClaim);
+
+    assertThat(claim.orgEntries()).hasSize(1);
+    assertThat(claim.orgEntries().getFirst().orgLevelRight()).isEqualTo("admin");
+    assertThat(claim.orgEntries().getFirst().functions()).isEmpty();
+  }
+
   @Test
   void parse_skipsEntryWithInvalidOrgId() {
     final List<Map<String, Object>> rawClaim = List.of(

--- a/keycloak/org-rights-mapper/README.md
+++ b/keycloak/org-rights-mapper/README.md
@@ -15,14 +15,24 @@ user has access to, with a nested `functions` array listing the individual right
 Rights are represented by the leaf groups `_admin`, `_write`, and `_read`. The mapper
 recognizes two grant patterns:
 
-- **Org-level right** — the user is a member of `orgs/{org}/{_admin|_write|_read}`. The
-  resulting `functions` entry uses `"*"` as the function name, indicating the right applies
-  across all functions in that organization.
+- **Org-level right** — the user is a member of `orgs/{org}/{_admin|_write|_read}`. The right is
+  **expanded** into one `functions` entry per function currently attached to that organization,
+  and additionally recorded in the `org_level_right` field for provenance. No wildcard is
+  emitted, so consumers never have to resolve the attachment set themselves.
 
 - **Function-level right** — the user is a member of `orgs/{org}/{function}/{_admin|_write|_read}`.
   The resulting `functions` entry names the specific function.
 
-**Example claim for a user with mixed memberships:**
+Where both apply to the same function, the **highest** right wins (`admin` > `write` > `read`),
+and exactly one entry per function is emitted.
+
+The attached functions of an organization are its sub-groups other than the three reserved right
+groups `_admin`, `_write` and `_read`. Matching those three names exactly — rather than
+filtering on a leading underscore — keeps a legal function identifier such as `_foo` from being
+dropped.
+
+**Example claim** for a user with org-level `write` on `5590026042` (which has `walletreg` and
+`reporting` attached) and an explicit function-level `admin` on `walletreg`:
 
 ```json
 "org_rights": [
@@ -30,13 +40,24 @@ recognizes two grant patterns:
     "organization_identifier": "5590026042",
     "organization_name#sv": "Exempelorganisationen",
     "organization_name#en": "Example Organization",
+    "org_level_right": "write",
     "functions": [
-      { "function": "walletreg", "right": "write" },
-      { "function": "reporting", "right": "read" }
+      { "function": "walletreg", "right": "admin" },
+      { "function": "reporting", "right": "write" }
     ]
   }
 ]
 ```
+
+**`org_level_right` confers no access.** It records only that the right was granted org-wide.
+Effective rights come exclusively from `functions`; a consumer that treats `org_level_right` as
+a grant would give access to functions that are not attached to the organization. Its one
+legitimate use is deciding whether the user may administer the organization itself.
+
+An org-level right on an organization with **no attached functions** yields an entry with
+`org_level_right` set and `"functions": []`. The entry is still emitted so the organization
+remains enumerable by relying parties; the empty array conveys that no function-level access
+follows.
 
 **Superuser shortcut** — if the user holds the `superuser` realm role the mapper emits a
 single-element array with just `{ "superuser": true }`, bypassing the group walk entirely:
@@ -60,7 +81,7 @@ orgs/
     _admin                 ← org-level admin right
     _write                 ← org-level write right
     _read                  ← org-level read right
-    {function-group}/
+    {function-group}/        ← an attached function (attribute: function_ref)
       _admin               ← function-level admin right
       _write               ← function-level write right
       _read                ← function-level read right
@@ -69,6 +90,11 @@ orgs/
 The organization attributes (`organization_identifier`, `organization_name#sv`,
 `organization_name#en`) are read from the org group and included verbatim in each
 `org_rights` entry.
+
+The function sub-groups are also the attachment set an org-level right is expanded onto. They
+are identified by name (anything that is not `_admin`, `_write` or `_read`) rather than by their
+`function_ref` attribute: reading the attribute would cost one extra load per sub-group, and a
+hand-provisioned realm that omitted it would silently lose the user's rights.
 
 ## Build
 

--- a/keycloak/org-rights-mapper/src/main/java/se/swedenconnect/iam/keycloak/orgrights/OrgRightsMapper.java
+++ b/keycloak/org-rights-mapper/src/main/java/se/swedenconnect/iam/keycloak/orgrights/OrgRightsMapper.java
@@ -45,6 +45,12 @@ import java.util.stream.Collectors;
  * describes all rights the user holds across organizations and functions, derived entirely from
  * the user's group memberships in the Keycloak group tree under the top-level {@code orgs} group.
  *
+ * <p>A right granted at the organization level (membership in {@code orgs/{orgId}/_admin},
+ * {@code /_write} or {@code /_read}) is expanded into one entry per function <em>currently
+ * attached</em> to that organization, and additionally recorded as
+ * {@link #CLAIM_FIELD_ORG_LEVEL_RIGHT} for provenance. Consumers therefore never have to resolve
+ * the attachment set themselves.</p>
+ *
  * @author Martin Lindström
  */
 public class OrgRightsMapper extends AbstractOIDCProtocolMapper
@@ -115,7 +121,7 @@ public class OrgRightsMapper extends AbstractOIDCProtocolMapper
 
   /**
    * Claim entry field (inside each element of {@link #CLAIM_FIELD_FUNCTIONS}):
-   * the function name, or {@link #FUNCTION_WILDCARD} for an org-level right.
+   * the name of a function attached to the organization.
    */
   public static final String CLAIM_FIELD_FUNCTION = "function";
 
@@ -125,16 +131,18 @@ public class OrgRightsMapper extends AbstractOIDCProtocolMapper
    */
   public static final String CLAIM_FIELD_RIGHT = "right";
 
+  /**
+   * Claim entry field: the right the user was granted at the organization level, if any.
+   *
+   * <p>This field records <em>how</em> a right was granted — it is provenance only and confers
+   * no access by itself. Effective rights are given exclusively by {@link #CLAIM_FIELD_FUNCTIONS},
+   * into which an org-level right has already been expanded (one entry per attached function).
+   * The field is absent when the user holds no org-level right.</p>
+   */
+  public static final String CLAIM_FIELD_ORG_LEVEL_RIGHT = "org_level_right";
+
   /** Claim entry field: the superuser flag, used in the superuser shortcut entry. */
   public static final String CLAIM_FIELD_SUPERUSER = "superuser";
-
-  // ---- Special function value ----
-
-  /**
-   * Wildcard function name used in the {@link #CLAIM_FIELD_FUNCTIONS} array to indicate
-   * that a right was granted at the organization level (covering all functions).
-   */
-  public static final String FUNCTION_WILDCARD = "*";
 
   // -------------------------------------------------------------------------
 
@@ -212,10 +220,10 @@ public class OrgRightsMapper extends AbstractOIDCProtocolMapper
       return;
     }
 
-    // Step 4 — Classify group memberships and accumulate function entries per org.
+    // Step 4 — Classify group memberships and accumulate rights per org.
     // key   = org group name (= group name directly under orgs)
-    // value = list of { "function": <name|"*">, "right": <right> } maps
-    final Map<String, List<Map<String, String>>> orgFunctionEntries = new LinkedHashMap<>();
+    // value = the org-level right (if any) plus the function-level rights, highest per function
+    final Map<String, OrgRights> orgRights = new LinkedHashMap<>();
 
     for (final GroupModel group : userGroups) {
       LOG.debugf("[org-rights] Inspecting group '%s' (id=%s)", group.getName(), group.getId());
@@ -238,12 +246,12 @@ public class OrgRightsMapper extends AbstractOIDCProtocolMapper
           group.getName(), parent.getName(), parent.getParentId());
 
       if (parent.getParentId() != null && parent.getParentId().equals(orgsGroup.getId())) {
-        // parent is a direct child of orgs → org-level right; wildcard function
+        // parent is a direct child of orgs → org-level right. The set of functions to expand it
+        // onto is not known until the org group is loaded in Step 5, so only record it here.
         final String orgIdentifier = parent.getName();
         LOG.debugf("[org-rights]   Resolved to org-level right '%s' on org '%s'", right, orgIdentifier);
-        orgFunctionEntries
-            .computeIfAbsent(orgIdentifier, k -> new ArrayList<>())
-            .add(functionEntry(FUNCTION_WILDCARD, right));
+        final OrgRights rights = orgRights.computeIfAbsent(orgIdentifier, k -> new OrgRights());
+        rights.orgLevelRight = highestRight(rights.orgLevelRight, right);
       }
       else {
         // Check if grandparent is a direct child of orgs → function-level right
@@ -261,9 +269,9 @@ public class OrgRightsMapper extends AbstractOIDCProtocolMapper
           final String functionName = parent.getName();
           LOG.debugf("[org-rights]   Resolved to function-level right '%s' on org '%s', function '%s'",
               right, orgIdentifier, functionName);
-          orgFunctionEntries
-              .computeIfAbsent(orgIdentifier, k -> new ArrayList<>())
-              .add(functionEntry(functionName, right));
+          orgRights
+              .computeIfAbsent(orgIdentifier, k -> new OrgRights())
+              .functionRights.merge(functionName, right, OrgRightsMapper::highestRight);
         }
         else {
           LOG.debugf("[org-rights]   Skipping '%s' — hierarchy too deep or not under '%s'",
@@ -273,9 +281,10 @@ public class OrgRightsMapper extends AbstractOIDCProtocolMapper
     }
 
     LOG.debugf("[org-rights] Classified memberships into %d org(s): %s",
-        orgFunctionEntries.size(), orgFunctionEntries.keySet());
+        orgRights.size(), orgRights.keySet());
 
-    // Step 5 — Build one claim entry per organization.
+    // Step 5 — Build one claim entry per organization, expanding org-level rights onto the
+    // functions currently attached to the organization.
     // Collect org sub-groups once to avoid one getSubGroupsStream() call per org.
     final Map<String, GroupModel> orgGroupByName = orgsGroup.getSubGroupsStream()
         .collect(Collectors.toMap(GroupModel::getName, g -> g));
@@ -283,9 +292,9 @@ public class OrgRightsMapper extends AbstractOIDCProtocolMapper
 
     final List<Map<String, Object>> entries = new ArrayList<>();
 
-    for (final Map.Entry<String, List<Map<String, String>>> e : orgFunctionEntries.entrySet()) {
+    for (final Map.Entry<String, OrgRights> e : orgRights.entrySet()) {
       final String orgIdentifier = e.getKey();
-      final List<Map<String, String>> functionEntries = e.getValue();
+      final OrgRights rights = e.getValue();
 
       final GroupModel orgGroup = orgGroupByName.get(orgIdentifier);
       if (orgGroup == null) {
@@ -297,13 +306,35 @@ public class OrgRightsMapper extends AbstractOIDCProtocolMapper
       final String orgNameEn = readOrgAttribute(orgGroup, ATTR_ORGANIZATION_NAME_EN, orgIdentifier);
       final String orgId     = readOrgAttribute(orgGroup, ATTR_ORGANIZATION_IDENTIFIER, orgIdentifier);
 
-      LOG.debugf("[org-rights] Building entry for org '%s' (id=%s, sv='%s', en='%s') with %d function(s): %s",
-          orgIdentifier, orgId, orgNameSv, orgNameEn, functionEntries.size(), functionEntries);
+      // Effective right per function: the org-level right expanded onto every attached function,
+      // then raised by any explicit function-level right the user holds.
+      final Map<String, String> effectiveRights = new LinkedHashMap<>();
+      final String orgLevelRight = rights.orgLevelRight;
+      if (orgLevelRight != null) {
+        for (final String functionId : attachedFunctions(orgGroup, orgIdentifier)) {
+          effectiveRights.put(functionId, orgLevelRight);
+        }
+        LOG.debugf("[org-rights] Expanded org-level right '%s' on org '%s' onto %d attached function(s)",
+            orgLevelRight, orgIdentifier, effectiveRights.size());
+      }
+      rights.functionRights.forEach((f, r) -> effectiveRights.merge(f, r, OrgRightsMapper::highestRight));
+
+      final List<Map<String, String>> functionEntries = effectiveRights.entrySet().stream()
+          .map(fr -> functionEntry(fr.getKey(), fr.getValue()))
+          .toList();
+
+      LOG.debugf("[org-rights] Building entry for org '%s' (id=%s, sv='%s', en='%s', %s=%s) "
+              + "with %d function(s): %s",
+          orgIdentifier, orgId, orgNameSv, orgNameEn, CLAIM_FIELD_ORG_LEVEL_RIGHT, orgLevelRight,
+          functionEntries.size(), functionEntries);
 
       final Map<String, Object> entry = new LinkedHashMap<>();
       entry.put(ATTR_ORGANIZATION_IDENTIFIER, orgId);
       entry.put(ATTR_ORGANIZATION_NAME_SV, orgNameSv);
       entry.put(ATTR_ORGANIZATION_NAME_EN, orgNameEn);
+      if (orgLevelRight != null) {
+        entry.put(CLAIM_FIELD_ORG_LEVEL_RIGHT, orgLevelRight);
+      }
       entry.put(CLAIM_FIELD_FUNCTIONS, functionEntries);
       entries.add(entry);
     }
@@ -331,9 +362,70 @@ public class OrgRightsMapper extends AbstractOIDCProtocolMapper
   }
 
   /**
+   * Returns the rank of a right, used to resolve the highest right when several apply to the same
+   * function. Rights are hierarchical: {@code admin} &gt; {@code write} &gt; {@code read}.
+   *
+   * @param right the right string
+   * @return the rank, or {@code 0} for an unrecognized right
+   */
+  private static int rightRank(final @NonNull String right) {
+    return switch (right) {
+      case RIGHT_ADMIN -> 3;
+      case RIGHT_WRITE -> 2;
+      case RIGHT_READ  -> 1;
+      default -> 0;
+    };
+  }
+
+  /**
+   * Returns the higher of two rights.
+   *
+   * @param current the right resolved so far, or {@code null} if none
+   * @param candidate the right to compare against
+   * @return {@code candidate} if it outranks {@code current}, otherwise {@code current}
+   */
+  private static @NonNull String highestRight(
+      final @Nullable String current, final @NonNull String candidate) {
+    return current == null || rightRank(candidate) > rightRank(current) ? candidate : current;
+  }
+
+  /**
+   * Returns the names of the functions currently attached to an organization.
+   *
+   * <p>Attachments are the org group's sub-groups, identified by exclusion: everything that is not
+   * one of the three reserved right groups ({@link #RIGHT_GROUP_ADMIN}, {@link #RIGHT_GROUP_WRITE},
+   * {@link #RIGHT_GROUP_READ}). Matching the reserved names exactly rather than filtering on a
+   * leading underscore keeps function identifiers such as {@code _foo} — legal per the admin
+   * application's {@code [a-z0-9_-]+} rule — from being silently dropped. The {@code function_ref}
+   * attribute each attachment sub-group carries is deliberately not required: reading it would cost
+   * one attribute load per sub-group, and a hand-provisioned realm that omitted it would silently
+   * lose the user's rights.</p>
+   *
+   * @param orgGroup the organization group, may be {@code null} if it could not be resolved
+   * @param orgIdentifier the org identifier used in log messages
+   * @return the attached function names, in Keycloak's iteration order; never {@code null}
+   */
+  private @NonNull List<String> attachedFunctions(
+      final @Nullable GroupModel orgGroup, final @NonNull String orgIdentifier) {
+
+    if (orgGroup == null) {
+      LOG.debugf("[org-rights] Cannot resolve attached functions for org '%s' — org group not found",
+          orgIdentifier);
+      return List.of();
+    }
+    final List<String> functions = orgGroup.getSubGroupsStream()
+        .map(GroupModel::getName)
+        .filter(name -> name != null && rightFromGroupName(name) == null)
+        .toList();
+    LOG.debugf("[org-rights] Org '%s' has %d attached function(s): %s",
+        orgIdentifier, functions.size(), functions);
+    return functions;
+  }
+
+  /**
    * Builds a single function-right entry for the {@link #CLAIM_FIELD_FUNCTIONS} array.
    *
-   * @param functionName the function name, or {@link #FUNCTION_WILDCARD} for an org-level right
+   * @param functionName the name of a function attached to the organization
    * @param right the right string ({@link #RIGHT_ADMIN}, {@link #RIGHT_WRITE}, or {@link #RIGHT_READ})
    * @return a two-key map with {@link #CLAIM_FIELD_FUNCTION} and {@link #CLAIM_FIELD_RIGHT}
    */
@@ -368,5 +460,18 @@ public class OrgRightsMapper extends AbstractOIDCProtocolMapper
       return "";
     }
     return values.getFirst();
+  }
+
+  /**
+   * The rights a user holds within a single organization, as accumulated from the user's group
+   * memberships before the org-level right is expanded onto the organization's attached functions.
+   */
+  private static final class OrgRights {
+
+    /** The highest right granted at the organization level, or {@code null} if none. */
+    private @Nullable String orgLevelRight;
+
+    /** The highest right granted per named function, keyed by function name. */
+    private final @NonNull Map<String, String> functionRights = new LinkedHashMap<>();
   }
 }

--- a/keycloak/org-rights-mapper/src/test/java/se/swedenconnect/iam/keycloak/orgrights/OrgRightsMapperTest.java
+++ b/keycloak/org-rights-mapper/src/test/java/se/swedenconnect/iam/keycloak/orgrights/OrgRightsMapperTest.java
@@ -35,9 +35,11 @@ import org.mockito.quality.Strictness;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -47,10 +49,10 @@ import static se.swedenconnect.iam.keycloak.orgrights.OrgRightsMapper.ATTR_ORGAN
 import static se.swedenconnect.iam.keycloak.orgrights.OrgRightsMapper.ATTR_ORGANIZATION_NAME_SV;
 import static se.swedenconnect.iam.keycloak.orgrights.OrgRightsMapper.CLAIM_FIELD_FUNCTION;
 import static se.swedenconnect.iam.keycloak.orgrights.OrgRightsMapper.CLAIM_FIELD_FUNCTIONS;
+import static se.swedenconnect.iam.keycloak.orgrights.OrgRightsMapper.CLAIM_FIELD_ORG_LEVEL_RIGHT;
 import static se.swedenconnect.iam.keycloak.orgrights.OrgRightsMapper.CLAIM_FIELD_RIGHT;
 import static se.swedenconnect.iam.keycloak.orgrights.OrgRightsMapper.CLAIM_FIELD_SUPERUSER;
 import static se.swedenconnect.iam.keycloak.orgrights.OrgRightsMapper.CLAIM_NAME;
-import static se.swedenconnect.iam.keycloak.orgrights.OrgRightsMapper.FUNCTION_WILDCARD;
 import static se.swedenconnect.iam.keycloak.orgrights.OrgRightsMapper.GROUP_ORGS;
 import static se.swedenconnect.iam.keycloak.orgrights.OrgRightsMapper.REALM_ROLE_SUPERUSER;
 import static se.swedenconnect.iam.keycloak.orgrights.OrgRightsMapper.RIGHT_ADMIN;
@@ -124,11 +126,12 @@ class OrgRightsMapperTest {
   }
 
   /**
-   * Test 2: Org-level right. User is a member of orgs/5590026042/_write.
-   * Expected: one entry with functions=[{function:"*", right:"write"}].
+   * Test 2: Org-level right. User is a member of orgs/5590026042/_write, and the organization has
+   * the functions demo and walletreg attached.
+   * Expected: org_level_right=write, and the right expanded onto both attached functions.
    */
   @Test
-  void testOrgLevelRight() {
+  void testOrgLevelRightExpandsOntoAttachedFunctions() {
     when(realm.getRole(REALM_ROLE_SUPERUSER)).thenReturn(null);
 
     final GroupModel orgsGroup = mockGroup("orgs-id", GROUP_ORGS, null);
@@ -142,6 +145,8 @@ class OrgRightsMapperTest {
         ATTR_ORGANIZATION_NAME_SV,    List.of("Litsec AB"),
         ATTR_ORGANIZATION_NAME_EN,    List.of("Litsec AB")));
     when(orgGroup.getParentId()).thenReturn("orgs-id");
+    mockOrgChildren(orgGroup, "demo", "walletreg",
+        RIGHT_GROUP_ADMIN, RIGHT_GROUP_WRITE, RIGHT_GROUP_READ);
 
     final GroupModel writeGroup = mockGroup("org-write-id", RIGHT_GROUP_WRITE, "org1-id");
     when(writeGroup.getParent()).thenReturn(orgGroup);
@@ -162,19 +167,103 @@ class OrgRightsMapperTest {
     assertEquals("5590026042", entry.get(ATTR_ORGANIZATION_IDENTIFIER));
     assertEquals("Litsec AB",  entry.get(ATTR_ORGANIZATION_NAME_SV));
     assertEquals("Litsec AB",  entry.get(ATTR_ORGANIZATION_NAME_EN));
+    assertEquals(RIGHT_WRITE,  entry.get(CLAIM_FIELD_ORG_LEVEL_RIGHT));
     assertTrue(entry.containsKey(CLAIM_FIELD_FUNCTIONS));
+
+    assertEquals(Map.of("demo", RIGHT_WRITE, "walletreg", RIGHT_WRITE), functionRights(entry));
+  }
+
+  /**
+   * Test 2b: The attachment set is identified by excluding the three reserved right-group names,
+   * not by a leading underscore — a function identifier such as {@code _foo} is legal per the admin
+   * application's {@code [a-z0-9_-]+} rule and must still receive the expanded right.
+   */
+  @Test
+  void testOrgLevelRightExpandsOntoUnderscoreFunctionId() {
+    when(realm.getRole(REALM_ROLE_SUPERUSER)).thenReturn(null);
+
+    final GroupModel orgsGroup = mockGroup("orgs-id", GROUP_ORGS, null);
+    when(realm.getTopLevelGroupsStream()).thenReturn(Stream.of(orgsGroup));
+    when(orgsGroup.getId()).thenReturn("orgs-id");
+
+    final GroupModel orgGroup = mockGroup("org1-id", "5590026042", "orgs-id");
+    when(orgsGroup.getSubGroupsStream()).thenReturn(Stream.of(orgGroup));
+    when(orgGroup.getAttributes()).thenReturn(Map.of(
+        ATTR_ORGANIZATION_IDENTIFIER, List.of("5590026042"),
+        ATTR_ORGANIZATION_NAME_SV,    List.of("Litsec AB"),
+        ATTR_ORGANIZATION_NAME_EN,    List.of("Litsec AB")));
+    when(orgGroup.getParentId()).thenReturn("orgs-id");
+    mockOrgChildren(orgGroup, "_foo", RIGHT_GROUP_ADMIN, RIGHT_GROUP_WRITE, RIGHT_GROUP_READ);
+
+    final GroupModel adminGroup = mockGroup("org-admin-id", RIGHT_GROUP_ADMIN, "org1-id");
+    when(adminGroup.getParent()).thenReturn(orgGroup);
+
+    when(user.getGroupsStream()).thenReturn(Stream.of(adminGroup));
+
+    final IDToken token = new IDToken();
+    mapper.setClaim(token, mappingModel, userSession, keycloakSession, clientSessionCtx);
+
+    @SuppressWarnings("unchecked")
+    final List<Map<String, Object>> orgRights =
+        (List<Map<String, Object>>) token.getOtherClaims().get(CLAIM_NAME);
+
+    assertNotNull(orgRights);
+    assertEquals(Map.of("_foo", RIGHT_ADMIN), functionRights(orgRights.get(0)));
+  }
+
+  /**
+   * Test 2c: Org-level right on an organization with no functions attached.
+   * Expected: the entry is still emitted, carrying org_level_right and an empty functions array.
+   */
+  @Test
+  void testOrgLevelRightWithNoAttachedFunctions() {
+    when(realm.getRole(REALM_ROLE_SUPERUSER)).thenReturn(null);
+
+    final GroupModel orgsGroup = mockGroup("orgs-id", GROUP_ORGS, null);
+    when(realm.getTopLevelGroupsStream()).thenReturn(Stream.of(orgsGroup));
+    when(orgsGroup.getId()).thenReturn("orgs-id");
+
+    final GroupModel orgGroup = mockGroup("org1-id", "5561234567", "orgs-id");
+    when(orgsGroup.getSubGroupsStream()).thenReturn(Stream.of(orgGroup));
+    when(orgGroup.getAttributes()).thenReturn(Map.of(
+        ATTR_ORGANIZATION_IDENTIFIER, List.of("5561234567"),
+        ATTR_ORGANIZATION_NAME_SV,    List.of("Exempel AB"),
+        ATTR_ORGANIZATION_NAME_EN,    List.of("Example Corp")));
+    when(orgGroup.getParentId()).thenReturn("orgs-id");
+    // Only the right groups exist — no function has been attached
+    mockOrgChildren(orgGroup, RIGHT_GROUP_ADMIN, RIGHT_GROUP_WRITE, RIGHT_GROUP_READ);
+
+    final GroupModel adminGroup = mockGroup("org-admin-id", RIGHT_GROUP_ADMIN, "org1-id");
+    when(adminGroup.getParent()).thenReturn(orgGroup);
+
+    when(user.getGroupsStream()).thenReturn(Stream.of(adminGroup));
+
+    final IDToken token = new IDToken();
+    mapper.setClaim(token, mappingModel, userSession, keycloakSession, clientSessionCtx);
+
+    @SuppressWarnings("unchecked")
+    final List<Map<String, Object>> orgRights =
+        (List<Map<String, Object>>) token.getOtherClaims().get(CLAIM_NAME);
+
+    assertNotNull(orgRights);
+    assertEquals(1, orgRights.size());
+
+    final Map<String, Object> entry = orgRights.get(0);
+    assertEquals("5561234567", entry.get(ATTR_ORGANIZATION_IDENTIFIER));
+    assertEquals("Example Corp", entry.get(ATTR_ORGANIZATION_NAME_EN));
+    assertEquals(RIGHT_ADMIN, entry.get(CLAIM_FIELD_ORG_LEVEL_RIGHT));
 
     @SuppressWarnings("unchecked")
     final List<Map<String, String>> functions =
         (List<Map<String, String>>) entry.get(CLAIM_FIELD_FUNCTIONS);
-    assertEquals(1, functions.size());
-    assertEquals(FUNCTION_WILDCARD, functions.get(0).get(CLAIM_FIELD_FUNCTION));
-    assertEquals(RIGHT_WRITE,       functions.get(0).get(CLAIM_FIELD_RIGHT));
+    assertNotNull(functions);
+    assertTrue(functions.isEmpty());
   }
 
   /**
    * Test 3: Function-level right. User is a member of orgs/5590026042/walletreg/_read.
-   * Expected: one entry with functions=[{function:"walletreg", right:"read"}].
+   * Expected: one entry with functions=[{function:"walletreg", right:"read"}] and no
+   * org_level_right field.
    */
   @Test
   void testFunctionLevelRight() {
@@ -212,6 +301,7 @@ class OrgRightsMapperTest {
 
     final Map<String, Object> entry = orgRights.get(0);
     assertEquals("5590026042", entry.get(ATTR_ORGANIZATION_IDENTIFIER));
+    assertFalse(entry.containsKey(CLAIM_FIELD_ORG_LEVEL_RIGHT));
 
     @SuppressWarnings("unchecked")
     final List<Map<String, String>> functions =
@@ -257,6 +347,7 @@ class OrgRightsMapperTest {
 
     final GroupModel adminB = mockGroup("adminB-id", RIGHT_GROUP_ADMIN, "orgB-id");
     when(adminB.getParent()).thenReturn(orgB);
+    mockOrgChildren(orgB, "demo", RIGHT_GROUP_ADMIN, RIGHT_GROUP_WRITE, RIGHT_GROUP_READ);
 
     // getSubGroupsStream called once per org during entry-building phase
     when(orgsGroup.getSubGroupsStream())
@@ -285,23 +376,18 @@ class OrgRightsMapperTest {
     final Map<String, Object> orgBEntry = firstEntry.get(ATTR_ORGANIZATION_IDENTIFIER).equals("2222222222")
         ? firstEntry : secondEntry;
 
-    @SuppressWarnings("unchecked")
-    final List<Map<String, String>> funcA = (List<Map<String, String>>) orgAEntry.get(CLAIM_FIELD_FUNCTIONS);
-    assertEquals(1, funcA.size());
-    assertEquals("walletreg", funcA.get(0).get(CLAIM_FIELD_FUNCTION));
-    assertEquals(RIGHT_READ,  funcA.get(0).get(CLAIM_FIELD_RIGHT));
+    assertFalse(orgAEntry.containsKey(CLAIM_FIELD_ORG_LEVEL_RIGHT));
+    assertEquals(Map.of("walletreg", RIGHT_READ), functionRights(orgAEntry));
 
-    @SuppressWarnings("unchecked")
-    final List<Map<String, String>> funcB = (List<Map<String, String>>) orgBEntry.get(CLAIM_FIELD_FUNCTIONS);
-    assertEquals(1, funcB.size());
-    assertEquals(FUNCTION_WILDCARD, funcB.get(0).get(CLAIM_FIELD_FUNCTION));
-    assertEquals(RIGHT_ADMIN,       funcB.get(0).get(CLAIM_FIELD_RIGHT));
+    assertEquals(RIGHT_ADMIN, orgBEntry.get(CLAIM_FIELD_ORG_LEVEL_RIGHT));
+    assertEquals(Map.of("demo", RIGHT_ADMIN), functionRights(orgBEntry));
   }
 
   /**
    * Test 5: Org-level and function-level on the same organization. User is a member of both
-   * orgs/5590026042/_read and orgs/5590026042/walletreg/_write. Both must appear in a single
-   * org entry's functions array.
+   * orgs/5590026042/_read and orgs/5590026042/walletreg/_write, with demo and walletreg attached.
+   * The org-level read is expanded onto both functions, and the explicit write on walletreg wins
+   * over it.
    */
   @Test
   void testOrgAndFunctionLevelOnSameOrg() {
@@ -318,6 +404,8 @@ class OrgRightsMapperTest {
         ATTR_ORGANIZATION_NAME_SV,    List.of("Litsec AB"),
         ATTR_ORGANIZATION_NAME_EN,    List.of("Litsec AB")));
     when(orgGroup.getParentId()).thenReturn("orgs-id");
+    mockOrgChildren(orgGroup, "demo", "walletreg",
+        RIGHT_GROUP_ADMIN, RIGHT_GROUP_WRITE, RIGHT_GROUP_READ);
 
     // Org-level _read membership
     final GroupModel orgReadGroup = mockGroup("org-read-id", RIGHT_GROUP_READ, "org1-id");
@@ -344,24 +432,10 @@ class OrgRightsMapperTest {
 
     final Map<String, Object> entry = orgRights.get(0);
     assertEquals("5590026042", entry.get(ATTR_ORGANIZATION_IDENTIFIER));
+    assertEquals(RIGHT_READ, entry.get(CLAIM_FIELD_ORG_LEVEL_RIGHT));
 
-    @SuppressWarnings("unchecked")
-    final List<Map<String, String>> functions =
-        (List<Map<String, String>>) entry.get(CLAIM_FIELD_FUNCTIONS);
-    assertEquals(2, functions.size());
-
-    // Find the wildcard and named entries by function value
-    final Map<String, String> wildcardEntry = functions.stream()
-        .filter(f -> FUNCTION_WILDCARD.equals(f.get(CLAIM_FIELD_FUNCTION)))
-        .findFirst()
-        .orElseThrow();
-    final Map<String, String> walletregEntry = functions.stream()
-        .filter(f -> "walletreg".equals(f.get(CLAIM_FIELD_FUNCTION)))
-        .findFirst()
-        .orElseThrow();
-
-    assertEquals(RIGHT_READ,  wildcardEntry.get(CLAIM_FIELD_RIGHT));
-    assertEquals(RIGHT_WRITE, walletregEntry.get(CLAIM_FIELD_RIGHT));
+    // demo gets the expanded org-level read; walletreg keeps the higher explicit write
+    assertEquals(Map.of("demo", RIGHT_READ, "walletreg", RIGHT_WRITE), functionRights(entry));
   }
 
   /**
@@ -409,6 +483,7 @@ class OrgRightsMapperTest {
         ATTR_ORGANIZATION_IDENTIFIER, List.of("5590026042"),
         ATTR_ORGANIZATION_NAME_EN,    List.of("Litsec AB")));
     when(orgGroup.getParentId()).thenReturn("orgs-id");
+    mockOrgChildren(orgGroup, "demo", RIGHT_GROUP_ADMIN, RIGHT_GROUP_WRITE, RIGHT_GROUP_READ);
 
     final GroupModel writeGroup = mockGroup("org-write-id", RIGHT_GROUP_WRITE, "org1-id");
     when(writeGroup.getParent()).thenReturn(orgGroup);
@@ -437,5 +512,24 @@ class OrgRightsMapperTest {
     when(g.getName()).thenReturn(name);
     when(g.getParentId()).thenReturn(parentId);
     return g;
+  }
+
+  /**
+   * Stubs the sub-groups of an org group — the attached function groups plus the org's own right
+   * groups. A fresh stream is answered on every call so repeated reads are safe.
+   */
+  private void mockOrgChildren(final GroupModel orgGroup, final String... childNames) {
+    when(orgGroup.getSubGroupsStream()).thenAnswer(invocation -> Stream.of(childNames)
+        .map(name -> mockGroup(orgGroup.getId() + "-" + name, name, orgGroup.getId())));
+  }
+
+  /** Reduces an org entry's functions array to a function-to-right map for easier assertions. */
+  private static Map<String, String> functionRights(final Map<String, Object> orgEntry) {
+    @SuppressWarnings("unchecked")
+    final List<Map<String, String>> functions =
+        (List<Map<String, String>>) orgEntry.get(CLAIM_FIELD_FUNCTIONS);
+    assertNotNull(functions);
+    return functions.stream().collect(
+        Collectors.toMap(f -> f.get(CLAIM_FIELD_FUNCTION), f -> f.get(CLAIM_FIELD_RIGHT)));
   }
 }


### PR DESCRIPTION
Closes #40 

The `org_rights` claim no longer uses the wildcard function `"*"`.

A right granted at the organisation level was previously emitted as
`{"function": "*", "right": "admin"}`. The wildcard was documented to mean "all functions currently
attached to this organisation", but the claim never carried the attachment set — so consumers could
not evaluate that condition and treated it as "all functions, attached or not". A function-scoped
application would grant access to an organisation that had never joined its function.

The `org-rights-mapper` plugin now expands an organisation-level right into one entry per **attached**
function, and records the org-wide grant in a new `org_level_right` field:

```json
{
  "organization_identifier": "5590026042",
  "org_level_right": "admin",
  "functions": [
    { "function": "demo", "right": "admin" },
    { "function": "walletreg", "right": "admin" }
  ]
}
```

`org_level_right` is **provenance only** — it says how a right was granted, never what the user may
do. Effective rights come exclusively from `functions`. Its one use is deciding whether someone may
administer the organisation itself (granting or revoking organisation-level rights, editing the
organisation record).

Also included: a new `OrgRightsClaim.organizations()` helper in `iam-security-base` for enumerating
the organisations a user is associated with, independent of granted authorities. An organisation with
an org-level right but no attached functions is emitted with an empty `functions` array — it appears
in the enumeration but produces no authorities.

### Behaviour change

Organisation-level `admin` on an organisation with no attached functions previously granted access to
every function; it now grants none. More generally, a function-scoped relying party no longer accepts
an organisation-level right for a function that was never attached. Rights that were correct before
are unchanged.

The OAuth scope path is unaffected — Keycloak already enforced attachment there, since the
`{org}:{function}:{right}` client scopes are created on attach and deleted on detach.

## After merging

Reinstall the Keycloak plugin JARs and restart Keycloak:

```bash
./compose/keycloak-scripts/install-keycloak-plugins.sh
docker compose -f compose/docker-compose.yml restart keycloak
```

Rebuilding the applications alone is not enough — the claim is written by the plugin and read by the
libraries, so both sides have to be updated or users silently lose their rights.

No realm configuration, group attributes, client scopes or protocol-mapper instances need to change.
A Keycloak instance running `start --optimized` needs an explicit `kc.sh build` first.

Downstream projects consuming `iam-security` must upgrade the plugin **before** bumping their
dependency version.