### PR TITLE
fix: Explicitly set signature key use on client JWK 

### DIFF
--- a/iam-security/iam-security-spring-boot-starter/src/main/java/se/swedenconnect/iam/security/autoconfigure/IamSecurityClientAutoConfiguration.java
+++ b/iam-security/iam-security-spring-boot-starter/src/main/java/se/swedenconnect/iam/security/autoconfigure/IamSecurityClientAutoConfiguration.java
@@ -16,6 +16,7 @@
 package se.swedenconnect.iam.security.autoconfigure;
 
 import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.KeyUse;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -123,7 +124,9 @@ public class IamSecurityClientAutoConfiguration {
           "iam.security.client.credential is not configured — cannot create OIDC client JWK");
     }
     final PkiCredential credential = pkiCredentialFactory.createCredential(credentialProps);
-    return JwkTransformerFunction.function().apply(credential);
+    return JwkTransformerFunction.function()
+        .withKeyUseFunction(pkiCredential -> KeyUse.SIGNATURE)
+        .apply(credential);
   }
 
   /**


### PR DESCRIPTION
fix: Explicitly set signature key use on client JWK   The client JWK bean built from the configured PkiCredential relied on   JwkTransformerFunction's default key-use inference, which could yield   a JWK without an explicit `use=sig`. Force KeyUse.SIGNATURE so the   JWK is unambiguous for private_key_jwt client authentication.